### PR TITLE
Enable Travis CI, use child process, add `shellVerbose`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+sudo: required
+
+os:
+  - linux
+
+language: c
+dist: xenial
+
+matrix:
+  include:
+    # Build and test against the master (stable) and devel branches of Nim
+    # Build and test using both gcc and clang
+    - os: linux
+      env: CHANNEL=stable
+      compiler: gcc
+
+    - os: linux
+      env: CHANNEL=devel
+      compiler: gcc
+
+cache:
+  directories:
+    - "$HOME/.nimble"
+    - "$HOME/.choosenim"
+
+install:
+  - curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
+  - sh init.sh -y
+  - export PATH=$HOME/.nimble/bin:$PATH
+  - nimble refresh -y
+  - choosenim $CHANNEL
+
+script:
+  - nimble install -y
+  - nimble -y test

--- a/README.org
+++ b/README.org
@@ -1,5 +1,5 @@
 * shell
-https://travis-ci.com/Vindaar/shell.svg?branch=master
+[[https://travis-ci.com/Vindaar/shell][https://travis-ci.com/Vindaar/shell.svg?branch=master]]
 
 A mini Nim DSL to execute shell commands more conveniently.
 

--- a/README.org
+++ b/README.org
@@ -1,4 +1,5 @@
 * shell
+https://travis-ci.com/Vindaar/shell.svg?branch=master
 
 A mini Nim DSL to execute shell commands more conveniently.
 
@@ -10,14 +11,17 @@ shell:
   mv foo bar
   rm bar
 #+END_SRC
-which is then rewritten to:
+which is then rewritten to something equivalent to:
 #+BEGIN_SRC nim
 execShell("touch foo")
 execShell("mv foo bar")
 execShell("rm bar")
 #+END_SRC
-where =execShell= is a proc around =execCmdEx= (not around
-=execShellCmd= in order to get the output and return value).
+where =execShell= is a proc around =startProcess= for normal
+compilation and `gorgeEx` when using NimScript. 
+
+See [[Full expansion of the macro]] below for more details and how to read
+the exit code of executed commands.
 
 Most simple things should work as expected. See below for some known
 quirks.
@@ -184,6 +188,60 @@ shell:
 
 In general, if in doubt you can just write strings or triple string
 (to pass a ="= to the shell).
+
+** Full expansion of the macro
+
+As mentioned at the top of the README, the expansion shown is
+simplified (as a matter of fact it was as simple once, but has since
+become more complex).
+
+The full expansion of the first example is:
+#+BEGIN_SRC nim
+discard block:
+  var outputStr381052 = ""
+  var exitCode381051: int
+  let tmp381063 = execShell("touch foo")
+  if exitCode381051 ==
+      0:
+    outputStr381052 = outputStr381052 &
+        tmp381063[0]
+    exitCode381051 = tmp381063[1]
+  else:
+    echo "Skipped command `" & "touch foo" &
+        "` due to failure in previous command!"
+  let tmp381064 = execShell("mv foo bar")
+  if exitCode381051 ==
+      0:
+    outputStr381052 = outputStr381052 &
+        tmp381064[0]
+    exitCode381051 = tmp381064[1]
+  else:
+    echo "Skipped command `" & "mv foo bar" &
+        "` due to failure in previous command!"
+  let tmp381065 = execShell("rm bar")
+  if exitCode381051 ==
+      0:
+    outputStr381052 = outputStr381052 &
+        tmp381065[0]
+    exitCode381051 = tmp381065[1]
+  else:
+    echo "Skipped command `" & "rm bar" &
+        "` due to failure in previous command!"
+  (outputStr381052, exitCode381051)
+#+END_SRC
+
+As can be seen from the expansion above, successive commands are only
+run, if the exit code of the previous command was 0, while the output
+is appended to the previous command's output.
+
+The normal =shell= command discard the return value of the block. If
+you want to keep it, use the =shellVerbose= macro:
+#+BEGIN_SRC nim
+let res = shellVerbose:
+  someCommand
+#+END_SRC
+where =res= will be of type =tuple[output: string, exitCode: string]=.
+
 
 ** Debugging
 In order to see what's going on, you can either compile your program

--- a/README.org
+++ b/README.org
@@ -234,14 +234,14 @@ As can be seen from the expansion above, successive commands are only
 run, if the exit code of the previous command was 0, while the output
 is appended to the previous command's output.
 
-The normal =shell= command discard the return value of the block. If
+The normal =shell= command discards the return value of the block. If
 you want to keep it, use the =shellVerbose= macro:
 #+BEGIN_SRC nim
 let res = shellVerbose:
   someCommand
 #+END_SRC
-where =res= will be of type =tuple[output: string, exitCode: string]=.
-
+where =res= will be of type =tuple[output: string, exitCode: string]=
+according to the expansion above.
 
 ** Debugging
 In order to see what's going on, you can either compile your program

--- a/shell.nim
+++ b/shell.nim
@@ -287,9 +287,12 @@ macro checkShell*(cmds: untyped, exp: untyped): untyped =
 
   if exp.kind == nnkStmtList:
     let checkCommand = nilOrQuote(shCmds[0])
-    result = quote do:
-      check `checkCommand` == `exp[0]`
-
+    when not defined(NimScript):
+      result = quote do:
+        check `checkCommand` == `exp[0]`
+    else:
+      result = quote do:
+        doAssert `checkCommand` == `exp[0]`
   when defined(debugShell):
     echo result.repr
 

--- a/shell.nimble
+++ b/shell.nimble
@@ -12,3 +12,5 @@ requires "nim >= 0.19.0"
 
 task test, "executes the tests":
   exec "nim c -d:debugShell -r tests/tShell.nim"
+  # execute using NimScript as well
+  exec "nim e -d:debugShell -r tests/tShell.nims"

--- a/shell.nimble
+++ b/shell.nimble
@@ -13,4 +13,4 @@ requires "nim >= 0.19.0"
 task test, "executes the tests":
   exec "nim c -d:debugShell -r tests/tShell.nim"
   # execute using NimScript as well
-  exec "nim e -d:debugShell -r tests/tShell.nims"
+  exec "nim e -d:debugShell -r tests/tNimScript.nims"

--- a/tests/tNimScript.nims
+++ b/tests/tNimScript.nims
@@ -1,0 +1,145 @@
+import ../shell
+
+checkShell:
+  cd "Analysis/ingrid"
+do:
+  "cd Analysis/ingrid"
+
+checkShell:
+  cd Analysis/ingrid/stuff
+do:
+  "cd Analysis/ingrid/stuff"
+
+checkShell:
+  run test.h5
+do:
+  "run test.h5"
+
+checkShell:
+  "cd Analysis"
+do:
+  "cd Analysis"
+
+checkShell:
+  nimble develop
+do:
+  "nimble develop"
+
+checkShell:
+  ./reconstruction "Run123" "--out" "test.h5"
+do:
+  "./reconstruction Run123 --out test.h5"
+
+checkShell:
+  ./reconstruction Run123 "--out" "test.h5"
+do:
+  "./reconstruction Run123 --out test.h5"
+
+checkShell:
+  ./reconstruction Run123 "--out" test.h5
+do:
+  "./reconstruction Run123 --out test.h5"
+
+checkShell:
+  ./reconstruction Run123 --out test.h5
+do:
+  "./reconstruction Run123 --out test.h5"
+
+checkShell:
+  ./reconstruction Run123 --out
+do:
+  "./reconstruction Run123 --out"
+
+
+checkShell:
+  ./reconstruction Run123 """--out="test.h5""""
+do:
+  "./reconstruction Run123 --out=\"test.h5\""
+
+checkShell:
+  echo """"test file"""" > test.txt
+do:
+  "echo \"test file\" > test.txt"
+
+checkShell:
+  cat test.txt | grep """"file""""
+do:
+  "cat test.txt | grep \"file\""
+
+checkShell:
+  mkdir foo && rmdir foo
+do:
+  "mkdir foo && rmdir foo"
+
+checkShell:
+  echo `Hallo`
+do:
+  "echo \"Hallo\""
+
+checkShell:
+  echo `"Hello World!"`
+do:
+  "echo \"Hello World!\""
+
+checkShell:
+  "a=`echo Hallo`"
+do:
+  "a=`echo Hallo`"
+
+shellEcho:
+  ./reconstruction Run123 --out test.h5
+
+shell:
+  touch test1234567890.txt
+  mv test1234567890.txt bar1234567890.txt
+  rm bar1234567890.txt
+
+checkShell:
+  one:
+    mkdir foo
+    cd foo
+    touch bar
+    cd ".."
+do:
+  "mkdir foo && cd foo && touch bar && cd .."
+
+checkShell:
+  pipe:
+    cat tests/tShell.nim
+    grep test
+    head -3
+do:
+  "cat tests/tShell.nim | grep test | head -3"
+
+let name = "Vindaar"
+checkShell:
+  echo "Hello from" `$name`
+do:
+  &"echo Hello from {name}"
+
+let dir = "testDir"
+checkShell:
+  tar -czf `$dir`.tar.gz
+do:
+  &"tar -czf {dir}.tar.gz"
+
+block:
+  var res = ""
+  shellAssign:
+    res = echo `hello`
+  doAssert res == "hello"
+
+block:
+  var res = ""
+  shellAssign:
+    res = pipe:
+      seq 0 1 10
+      tail -3
+  doAssert res == "8\n9\n10"
+
+block:
+  let ret = shellVerbose:
+    "for f in 1 2 3; do echo $f; sleep 1; done"
+  doAssert ret[0] == "1\n2\n3", "was " & $ret[0]
+
+echo "All tests passed using NimScript!"

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -113,11 +113,10 @@ suite "[shell]":
 
   test "[shell] multiple commands":
     shell:
-      touch test.txt
-      cp test.txt abc.txt
-      rm abc.txt
+      touch test1234567890.txt
+      mv test1234567890.txt bar1234567890.txt
+      rm bar1234567890.txt
     check true
-
 
   test "[shell] multiple commands in one shell call":
     checkShell:
@@ -165,3 +164,18 @@ suite "[shell]":
         seq 0 1 10
         tail -3
     check res == "8\n9\n10"
+
+  test "[shell] real time output":
+    shell:
+      "for f in 1 2 3; do echo $f; sleep 1; done"
+
+  test "[shellVerbose] check for exit code of wrong command":
+    let res = shellVerbose:
+      thisCommandDoesNotExistOnYourSystemOrThisTestWillFail
+    check res[1] != 0
+
+  test "[shellVerbose] compare output of command using shellVerbose":
+    let res = shellVerbose:
+      echo "Hello world!"
+    check res[0] == "Hello world!"
+    check res[1] == 0


### PR DESCRIPTION
- enables Travis CI
- `shell` now uses `startProcess` for a proper child process to allow writing the commands stdout in real time
- `shellVerbose` is added, which allows to read the full exit code / stdout output.