### PR TITLE
quote via () instead of ``

### DIFF
--- a/README.org
+++ b/README.org
@@ -110,11 +110,6 @@ and after the call to =strformat.&=:
 execShell("echo Hello from Vindaar!")
 #+END_SRC
 
-For more complicated use cases interpolation with normal strings is
-required though.
-
-
-
 *** Appending to a Nim identifier
 
 Assuming we have a filename identifier and we want to convert some
@@ -207,6 +202,27 @@ doAssert ($outfile "image2") == &"{fname} image2" # <- with space, ident first
 single string literal (or something that is convertible to a string
 via the =stringify= proc) and a single Nim identifier! This
 restriction will maybe be removed in the future.
+
+This syntax also works for more complicated Nim expressions than a
+simple identifier:
+#+BEGIN_SRC nim
+const t = (a: "name", b: 5.5)
+doAssert ("--out="$(t.a))
+doAssert ("--out="$t.a)
+#+END_SRC
+both work. Of course =t= needn't be a tuple. It can also be an object
+or even a function call, like for instance extracting a filename
+within a call:
+#+BEGIN_SRC nim
+import os, shell
+let path = "/some/user/path/toAFile.txt"
+shell:
+  ./myBin ("--inputFile="$(path.extractFilename))
+#+END_SRC
+should produce:
+#+BEGIN_SRC sh
+./myBin --inputFile=toAFile.txt
+#+END_SRC
 
 ** Accented quotes
 

--- a/README.org
+++ b/README.org
@@ -80,10 +80,141 @@ shell:
 #+END_SRC
 will work just as expected, echoing =Hallo= in the shell.
 
+** Nim symbol quoting
+
+*NOTE:* In a previous version this was done via accented quotes
+=`=. For the old behavior compile with =-d:oldQuote=.
+
+Another important feature to make this library useful is quoting of
+Nim symbols. 
+
+This is handled via parenthesis =()= (if you need to run something in
+a subshell unfortunately that will have to be done with an explicit
+string now). Any tree in =()= is subject to quoting. That means if an
+identifier within =()= is preceded by a =$=, the symbol is
+unquoted. Note however that for the moment only a single variable may
+be quoted in each =()=.
+
+The simplest case would be:
+#+BEGIN_SRC nim
+let name = "Vindaar"
+shell:
+  echo Hello from ($name)
+#+END_SRC 
+which will perform the call:
+#+BEGIN_SRC nim
+execShell(&"echo Hello from {name}!")
+#+END_SRC
+and after the call to =strformat.&=:
+#+BEGIN_SRC nim
+execShell("echo Hello from Vindaar!")
+#+END_SRC
+
+For more complicated use cases interpolation with normal strings is
+required though.
+
+
+
+*** Appending to a Nim identifier
+
+Assuming we have a filename identifier and we want to convert some
+image from =png= to =jpg= with image magick. The simplest command
+should look like:
+#+BEGIN_SRC sh
+convert myimage.png myimage.jpg
+#+END_SRC
+
+This can be done in several ways.
+
+1. Using dot expressions and no string literals:
+#+BEGIN_SRC nim
+let fname = "myimage"
+shell:
+  convert ($fname).png ($fname).jpg
+#+END_SRC 
+Note that this is a special case. Continuing after a =()= quote
+without literal strings will only work for dot expressions. For
+instance:
+#+BEGIN_SRC nim
+let fname = "myimage"
+shell:
+  convert ($fname)".png" ($fname)".jpg"
+#+END_SRC
+will wrongly be converted to:
+#+BEGIN_SRC sh
+convert myimage .png myimage .jpg
+#+END_SRC
+which is obviously not what one would expect.
+
+2. Using string literals:
+#+BEGIN_SRC nim
+let fname = "myimage"
+shell:
+  convert ($fname".pdf") ($fname".png")
+#+END_SRC
+In contrast to the wrong example shown above, this will work as
+expected.
+
+This is especially useful for cases without dot expressions after the
+quoted nim identifier.
+
+*** Appending a Nim identifier to a string literal
+
+The other example would be appending a Nim identifier to a literal
+string. For instance in case we have a filename, which we create at
+run time and we wish to hand it to some command which takes an
+argument, which is must be given without a space like:
+#+BEGIN_SRC sh
+./myBin input --out=output
+#+END_SRC
+
+In this case one of the following ways works:
+
+1. using =()= after a string literal:
+#+BEGIN_SRC nim
+let outfile = "myoutput.txt"
+shell:
+  ./myBin input "--out="($outfile)
+#+END_SRC
+If the =()= appears after the literal we can correctly generate the
+string without a space (in comparison to the case presented above when
+a string literal follows a =()=).
+
+2. For more predictable behavior, put the string literal also into
+   =()=:
+#+BEGIN_SRC nim
+let outfile = "myoutput.txt"
+shell:
+  ./myBin input ("--out="$outfile)
+#+END_SRC
+
+*** General remark on predictability
+
+If the most cohesive way is desired, which works in all use cases
+(with and without spaces) with the Nim identifier before and after a
+string literal, put everything into =()=. The =doAssert= below is to
+be understood in the context of the =shell= macro:
+#+BEGIN_SRC nim
+let outfile = "myoutput.txt"
+doAssert ("--out="$outfile) == &"--out={outfile}" # <- without space, ident after
+doAssert ("--out" $outfile) == &"--out {outfile}" # <- with space, ident after
+let fname = "myimage"
+doAssert ($outfile".jpg") == &"{fname}.jpg" # <- without space, ident first
+doAssert ($outfile "image2") == &"{fname} image2" # <- with space, ident first
+#+END_SRC
+
+*NOTE:* For the moment however, the =()= usage is restricted to a
+single string literal (or something that is convertible to a string
+via the =stringify= proc) and a single Nim identifier! This
+restriction will maybe be removed in the future.
+
 ** Accented quotes
 
-Accented quotes allow you to do two different things. Raw strings and
-Nim symbol quoting.
+*NOTE*: In a previous version accented quotes were also used to quote
+Nim identifiers. That use case is now handled via parentheses. For the
+old behavior compile with =-d:oldQuote=.
+
+Accented quotes allow you to hand raw strings.
 
 Note: this has the downside of disallowing =`= as a token to be handed
 to the shell. If you want to use the shell's =`=, you need to put the
@@ -110,24 +241,6 @@ which will then also be rewritten to:
 execShell("echo \"Hello from Nim!\"")
 #+END_SRC
 
-*** Nim symbol quoting
-
-Another important feature to make this library useful is quoting of
-Nim symbols. In order to support this, put the Nim symbol into
-accented quotes and in addition prefix it by =$= as:
-#+BEGIN_SRC nim
-let name = "Vindaar"
-shell:
-  echo Hello from `$name`
-#+END_SRC 
-which will perform the call:
-#+BEGIN_SRC nim
-execShell(&"echo Hello from {name}!")
-#+END_SRC
-and after the call to =strformat.&=:
-#+BEGIN_SRC nim
-execShell("echo Hello from Vindaar!")
-#+END_SRC
 
 ** Assignment of results to Nim variables
 

--- a/README.org
+++ b/README.org
@@ -126,7 +126,7 @@ convert myimage.png myimage.jpg
 
 This can be done in several ways.
 
-1. Using dot expressions and no string literals:
+**** Using dot expressions and no string literals:
 #+BEGIN_SRC nim
 let fname = "myimage"
 shell:
@@ -146,7 +146,7 @@ convert myimage .png myimage .jpg
 #+END_SRC
 which is obviously not what one would expect.
 
-2. Using string literals:
+**** Using string literals:
 #+BEGIN_SRC nim
 let fname = "myimage"
 shell:
@@ -170,7 +170,7 @@ argument, which is must be given without a space like:
 
 In this case one of the following ways works:
 
-1. using =()= after a string literal:
+**** using =()= after a string literal:
 #+BEGIN_SRC nim
 let outfile = "myoutput.txt"
 shell:
@@ -180,7 +180,7 @@ If the =()= appears after the literal we can correctly generate the
 string without a space (in comparison to the case presented above when
 a string literal follows a =()=).
 
-2. For more predictable behavior, put the string literal also into
+**** For more predictable behavior, put the string literal also into
    =()=:
 #+BEGIN_SRC nim
 let outfile = "myoutput.txt"

--- a/shell.nim
+++ b/shell.nim
@@ -83,8 +83,7 @@ proc parensUnquotePrefix(n: NimNode): string =
     let fixed = n.handleInfix
     if eqIdent(fixed[1], "$"):
       expectKind fixed[1], nnkIdent
-      expectKind fixed[2], nnkIdent
-      result = stringify(fixed[0]) & "{" & fixed[2].strVal & "}"
+      result = stringify(fixed[0]) & "{" & fixed[2].repr & "}"
     else:
       error("Unsupported symbol in parenthesis quote: " & $n.repr)
   of nnkPrefix:
@@ -97,12 +96,13 @@ proc parensUnquotePrefix(n: NimNode): string =
       case n[1].kind
       of nnkCallStrLit:
         expectKind n[1][0], nnkIdent
-        result = "{" & n[1][0].strVal & "}" & stringify(n[1][1])
+        result = "{" & n[1][0].repr & "}" & stringify(n[1][1])
       of nnkCommand:
         expectKind n[1][0], nnkIdent
-        result = "{" & n[1][0].strVal & "}" & " " & stringify(n[1][1])
+        result = "{" & n[1][0].repr & "}" & " " & stringify(n[1][1])
       else:
-        result = "{" & n[1].strVal & "}"
+        echo n.treeRepr
+        result = "{" & n[1].repr & "}"
     else:
       error("Unsupported symbol in parenthesis quote: " & $n.repr)
   of nnkCommand:

--- a/shell.nim
+++ b/shell.nim
@@ -101,7 +101,6 @@ proc parensUnquotePrefix(n: NimNode): string =
         expectKind n[1][0], nnkIdent
         result = "{" & n[1][0].repr & "}" & " " & stringify(n[1][1])
       else:
-        echo n.treeRepr
         result = "{" & n[1].repr & "}"
     else:
       error("Unsupported symbol in parenthesis quote: " & $n.repr)

--- a/shell.nim
+++ b/shell.nim
@@ -144,7 +144,6 @@ proc handleCall(n: NimNode): string =
 proc stringify(cmd: NimNode): string =
   ## Handles the stringification of a single `NimNode` according to its
   ## `NimNodeKind`.
-  echo "STRINGIFYING ", cmd.kind, " of value ", cmd.repr
   case cmd.kind
   of nnkCommand:
     result = iterateTree(cmd)
@@ -194,7 +193,6 @@ proc iterateTree(cmds: NimNode): string =
   ## main proc which iterates over tree and assigns assigns the correct
   ## strings to `subCmds` depending on NimNode kind
   var subCmds: seq[string]
-  echo cmds.treeRepr
   for cmd in cmds:
     subCmds.add stringify(cmd)
   result = subCmds.join(" ")

--- a/tests/tNimScript.nims
+++ b/tests/tNimScript.nims
@@ -114,15 +114,84 @@ do:
 
 let name = "Vindaar"
 checkShell:
-  echo "Hello from" `$name`
+  echo "Hello from" ($name)
 do:
   &"echo Hello from {name}"
 
 let dir = "testDir"
 checkShell:
-  tar -czf `$dir`.tar.gz
+  tar -czf ($dir).tar.gz
 do:
   &"tar -czf {dir}.tar.gz"
+
+block:
+  # "[shell] quoting a Nim symbol and appending to it using dotExpr":
+  let dir = "testDir"
+  checkShell:
+    tar -czf ($dir).tar.gz
+  do:
+    &"tar -czf {dir}.tar.gz"
+
+block:
+  # "[shell] unintuitive: quoting a Nim symbol (), appending string":
+  ## This is a rather unintuitive side effect of the way the Nim parser works.
+  ## Unfortunately appending a string literal to a quote via `()` will result
+  ## in a space between the quoted identifier and the string literal.
+  ## See the test case below, which quotes everything via `()`.
+  let dir = "testDir"
+  checkShell:
+    tar -czf ($dir)".tar.gz"
+  do:
+    &"tar -czf {dir} .tar.gz"
+
+block:
+  # "[shell] quoting a Nim symbol () and appending string inside the ()":
+  let dir = "testDir"
+  checkShell:
+    tar -czf ($dir".tar.gz")
+  do:
+    &"tar -czf {dir}.tar.gz"
+
+block:
+  # "[shell] quoting a Nim symbol () and appending string inside the () with a space":
+  let dir = "testDir"
+  checkShell:
+    tar -czf ($dir "aFile")
+  do:
+    &"tar -czf {dir} aFile"
+
+
+block:
+  # "[shell] quoting a Nim symbol and appending it to a string without space":
+  let outname = "test.h5"
+  checkShell:
+    ./test "--out="($outname)
+  do:
+    &"./test --out={outname}"
+
+block:
+  # "[shell] quoting a Nim symbol and appending it within `()`":
+  let outname = "test.h5"
+  checkShell:
+    ./test ("--out="$outname)
+  do:
+    &"./test --out={outname}"
+
+block:
+  # "[shell] quoting a Nim symbol and appending it within `()` with a space":
+  let outname = "test.h5"
+  checkShell:
+    ./test ("--out" $outname)
+  do:
+    &"./test --out {outname}"
+
+block:
+  # "[shell] quoting a Nim symbol and appending it to a string with space":
+  let outname = "test.h5"
+  checkShell:
+    ./test "--out" ($outname)
+  do:
+    &"./test --out {outname}"
 
 block:
   var res = ""

--- a/tests/tNimScript.nims
+++ b/tests/tNimScript.nims
@@ -194,6 +194,54 @@ block:
     &"./test --out {outname}"
 
 block:
+  # "[shell] quoting a Nim symbol with tuple fields":
+  const run = (name: "Run_240_181021-14-54", outName: "run_240.h5")
+  checkShell:
+    ./test "--in" ($run.name) "--out" ($(run.outName))
+  do:
+    &"./test --in {run.name} --out {run.outName}"
+
+block:
+  # "[shell] quoting a Nim symbol with tuple fields, appending to string":
+  const run = (name: "Run_240_181021-14-54", outName: "run_240.h5")
+  checkShell:
+    ./test ("--in="$(run.name)) ("--out="$(run.outName))
+  do:
+    &"./test --in={run.name} --out={run.outName}"
+
+block:
+  # "[shell] quoting a Nim symbol with tuple fields, appending to string without parens":
+  const run = (name: "Run_240_181021-14-54", outName: "run_240.h5")
+  checkShell:
+    ./test ("--in="$run.name) ("--out="$run.outName)
+  do:
+    &"./test --in={run.name} --out={run.outName}"
+
+block:
+  # "[shell] quoting a Nim expression with obj fields":
+  type
+    TestObj = object
+      name: string
+      val: float
+  let obj = TestObj(name: "test", val: 5.5)
+  checkShell:
+    ./test ("--in="$obj.name) ("--val="$(obj.val))
+  do:
+    &"./test --in={obj.name} --val={(obj.val)}"
+
+block:
+  # "[shell] quoting a Nim expression with proc call":
+  # sometimes calling a function on an identifier is useful, e.g. to extract
+  # a filename
+  proc extractFilename(s: string): string =
+    result = s[^11 .. ^1]
+  let path = "/some/user/path/toAFile.txt"
+  checkShell:
+    ./test ("--in="$(path.extractFilename))
+  do:
+    &"./test --in={path.extractFilename}"
+
+block:
   var res = ""
   shellAssign:
     res = echo `hello`

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -205,6 +205,49 @@ suite "[shell]":
     do:
       &"./test --out {outname}"
 
+  test "[shell] quoting a Nim symbol with tuple fields":
+    const run = (name: "Run_240_181021-14-54", outName: "run_240.h5")
+    checkShell:
+      ./test "--in" ($run.name) "--out" ($(run.outName))
+    do:
+      &"./test --in {run.name} --out {run.outName}"
+
+  test "[shell] quoting a Nim symbol with tuple fields, appending to string":
+    const run = (name: "Run_240_181021-14-54", outName: "run_240.h5")
+    checkShell:
+      ./test ("--in="$(run.name)) ("--out="$(run.outName))
+    do:
+      &"./test --in={run.name} --out={run.outName}"
+
+  test "[shell] quoting a Nim symbol with tuple fields, appending to string without parens":
+    const run = (name: "Run_240_181021-14-54", outName: "run_240.h5")
+    checkShell:
+      ./test ("--in="$run.name) ("--out="$run.outName)
+    do:
+      &"./test --in={run.name} --out={run.outName}"
+
+  test "[shell] quoting a Nim expression with obj fields":
+    type
+      TestObj = object
+        name: string
+        val: float
+    let obj = TestObj(name: "test", val: 5.5)
+    checkShell:
+      ./test ("--in="$obj.name) ("--val="$(obj.val))
+    do:
+      &"./test --in={obj.name} --val={(obj.val)}"
+
+  test "[shell] quoting a Nim expression with proc call":
+    # sometimes calling a function on an identifier is useful, e.g. to extract
+    # a filename
+    proc extractFilename(s: string): string =
+      result = s[^11 .. ^1]
+    let path = "/some/user/path/toAFile.txt"
+    checkShell:
+      ./test ("--in="$(path.extractFilename))
+    do:
+      &"./test --in={path.extractFilename}"
+
   test "[shellAssign] assigning output of a shell call to a Nim var":
     var res = ""
     shellAssign:


### PR DESCRIPTION
Quoting via `()` allows for easier concatenation of Nim identifiers
and string literals, which for many practical use cases (at least in
my experience) was pretty lacking with the previous accent quote based
approach.

Usage of () in bash is limited to subshell execution, which seems a
reasonable sacrifice. If something complicated enough is to be done
with this macro to warrant the bash usage of (), using a literal
string for this should be fine.

The readme has been updated to reflect the changes. Hopefully it's clear enough.