### PR TITLE
change quoting behavior with () again, avoid use () w/ spaces

### DIFF
--- a/README.org
+++ b/README.org
@@ -185,20 +185,23 @@ shell:
 
 *** General remark on predictability
 
-If the most cohesive way is desired, which works in all use cases
-(with and without spaces) with the Nim identifier before and after a
-string literal, put everything into =()=. The =doAssert= below is to
-be understood in the context of the =shell= macro:
+*NOTE:* previously this section said to handle quoting + concatenation
+with strings both in the case of with and without space with =()= for
+the most predictable behavior. But that was a bad idea from my side!
+If you need spaces, simply put it outside the =()= and use a space!
+
+The =doAssert= below is to be understood in the context of the =shell=
+macro. To summarize the above then: 
 #+BEGIN_SRC nim
 let outfile = "myoutput.txt"
 doAssert ("--out="$outfile) == &"--out={outfile}" # <- without space, ident after
-doAssert ("--out" $outfile) == &"--out {outfile}" # <- with space, ident after
+doAssert "--out" ($outfile) == &"--out {outfile}" # <- with space, ident after
 let fname = "myimage"
 doAssert ($outfile".jpg") == &"{fname}.jpg" # <- without space, ident first
-doAssert ($outfile "image2") == &"{fname} image2" # <- with space, ident first
+doAssert ($outfile) "image2" == &"{outfile} image2" # <- without space, ident first
 #+END_SRC
 
-*NOTE:* For the moment however, the =()= usage is restricted to a
+*NOTE 2:* For the moment however, the =()= usage is restricted to a
 single string literal (or something that is convertible to a string
 via the =stringify= proc) and a single Nim identifier! This
 restriction will maybe be removed in the future.

--- a/shell.nim
+++ b/shell.nim
@@ -91,15 +91,12 @@ proc parensUnquotePrefix(n: NimNode): string =
     # However, if something follows right after the quoted idenfitier without
     # a space, it'll be a
     # - `nnkCallStrLit` for `($dir".tar.gz")` <- no space
-    # - `nnkCommand` for `("--out" $name)` <- with space
+    # - `nnkCommand` for ``($(someExpr)"someString")` <- no space
     if eqIdent(n[0], "$"):
       case n[1].kind
-      of nnkCallStrLit:
-        expectKind n[1][0], nnkIdent
+      of nnkCommand, nnkCallStrLit:
+        doAssert n[1][0].kind in {nnkIdent, nnkPar}
         result = "{" & n[1][0].repr & "}" & stringify(n[1][1])
-      of nnkCommand:
-        expectKind n[1][0], nnkIdent
-        result = "{" & n[1][0].repr & "}" & " " & stringify(n[1][1])
       else:
         result = "{" & n[1].repr & "}"
     else:

--- a/shell.nimble
+++ b/shell.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Vindaar"
 description   = "A Nim mini DSL to execute shell commands"
 license       = "MIT"

--- a/tests/tNimScript.nims
+++ b/tests/tNimScript.nims
@@ -153,13 +153,12 @@ block:
     &"tar -czf {dir}.tar.gz"
 
 block:
-  # "[shell] quoting a Nim symbol () and appending string inside the () with a space":
-  let dir = "testDir"
+  # "[shell] quoting a Nim expression () and appending string inside the ()":
+  let pdf = "test.pdf"
   checkShell:
-    tar -czf ($dir "aFile")
+    pdfcrop "--margins '5 5 5 5'" ($pdf) ($(pdf.replace(".pdf",""))"_cropped.pdf")
   do:
-    &"tar -czf {dir} aFile"
-
+    &"pdfcrop --margins '5 5 5 5' {pdf} {pdf.replace(\".pdf\",\"\")}_cropped.pdf"
 
 block:
   # "[shell] quoting a Nim symbol and appending it to a string without space":
@@ -179,6 +178,7 @@ block:
 
 block:
   # "[shell] quoting a Nim symbol and appending it within `()` with a space":
+  ## NOTE: while this works, it is not the recommended way for clarity!
   let outname = "test.h5"
   checkShell:
     ./test ("--out" $outname)

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -169,13 +169,12 @@ suite "[shell]":
     do:
       &"tar -czf {dir}.tar.gz"
 
-  test "[shell] quoting a Nim symbol () and appending string inside the () with a space":
-    let dir = "testDir"
+  test "[shell] quoting a Nim expression () and appending string inside the ()":
+    let pdf = "test.pdf"
     checkShell:
-      tar -czf ($dir "aFile")
+      pdfcrop "--margins '5 5 5 5'" ($pdf) ($(pdf.replace(".pdf",""))"_cropped.pdf")
     do:
-      &"tar -czf {dir} aFile"
-
+      &"pdfcrop --margins '5 5 5 5' {pdf} {pdf.replace(\".pdf\",\"\")}_cropped.pdf"
 
   test "[shell] quoting a Nim symbol and appending it to a string without space":
     let outname = "test.h5"
@@ -192,6 +191,7 @@ suite "[shell]":
       &"./test --out={outname}"
 
   test "[shell] quoting a Nim symbol and appending it within `()` with a space":
+    ## NOTE: while this works, it is not the recommended way for clarity!
     let outname = "test.h5"
     checkShell:
       ./test ("--out" $outname)


### PR DESCRIPTION
If one desires spaces between the quoted expression and another
string, one should not put the string literal into the quote. There's
no point.

Attempting to support the above was a brainfart of mine. The main reason I had to drop it was to support
```nim
($(someExpression)"stringLiteral")
```
because from the AST then there is no way to differentiate the above from
```nim
($(someExpression) "stringLiteral")
```
so that we'd be back at square one (before the quote change from accented quotes to parens).