### PR TITLE
Allow only quote as single argument

### DIFF
--- a/shell.nim
+++ b/shell.nim
@@ -284,6 +284,8 @@ proc genShellCmds(cmds: NimNode): seq[string] =
       result.add cmd.strVal
     of nnkPrefix, nnkAccQuoted:
       result.add iterateTree(nnkIdentDefs.newTree(cmd))
+    of nnkPar:
+      result.add cmd.stringify
     else:
       error("Unsupported node kind: " & $cmd.kind & " for command " & cmd.repr &
         ". Consider putting offending part into \" \".")

--- a/tests/tNimScript.nims
+++ b/tests/tNimScript.nims
@@ -242,6 +242,15 @@ block:
     &"./test --in={path.extractFilename}"
 
 block:
+  # "[shell] quoting a Nim expression without anything else":
+  let myCmd = "runMe"
+  checkShell:
+    ($myCmd)
+  do:
+    $myCmd
+
+
+block:
   var res = ""
   shellAssign:
     res = echo `hello`

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -248,6 +248,13 @@ suite "[shell]":
     do:
       &"./test --in={path.extractFilename}"
 
+  test "[shell] quoting a Nim expression without anything else":
+    let myCmd = "runMe"
+    checkShell:
+      ($myCmd)
+    do:
+      $myCmd
+
   test "[shellAssign] assigning output of a shell call to a Nim var":
     var res = ""
     shellAssign:


### PR DESCRIPTION
As an oversight it wasn't possible to have a shell command only consist of the quoting of a Nim expression. This works now.