### PR TITLE
Configure what is being printed to stdout when executing command

### DIFF
--- a/shell.nim
+++ b/shell.nim
@@ -381,15 +381,14 @@ macro shellVerboseImpl*(debugConfig, cmds: untyped): untyped =
   for cmd in shCmds:
     let qCmd = nilOrQuote(cmd)
     result.add quote do:
-      let debugConfig = `debugConfig`
       # use the exit code to determine if next command should be run
       if `exCodeSym` == 0:
-        let tmp = execShell(`qCmd`, debugConfig)
+        let tmp = execShell(`qCmd`, `debugConfig`)
         `outputSym` = `outputSym` & tmp[0]
         `outerrSym` = tmp[1]
         `exCodeSym` = tmp[2]
       else:
-        if dokRuntime in debugConfig:
+        if dokRuntime in `debugConfig`:
           echo "Skipped command `" &
             `qCmd` &
             "` due to failure in previous command!"
@@ -499,4 +498,13 @@ macro shellAssign*(cmd: untyped): untyped =
     echo result.repr
 
 when isMainModule:
-  discard
+  var myConfig: set[DebugOutputKind] = {dokError}
+  let (res, _) = shellVerbose(myConfig):
+    echo "test"
+
+  echo "Result is: ", res
+
+  myConfig = {dokOutput}
+
+  let (res2, _) = shellVerbose(myConfig):
+    echo "test2"

--- a/shell.nim
+++ b/shell.nim
@@ -20,12 +20,25 @@ type
     dokOutput
     dokRuntime
 
-const defaultDebugConfig: set[DebugOutputKind] = {
-    when not defined shellNoDebugOutput: dokOutput,
-    when not defined shellNoDebugError: dokError,
-    when not defined shellNoDebugCommand: dokCommand,
-    when not defined shellNoDebugRuntime: dokRuntime,
-}
+const defaultDebugConfig: set[DebugOutputKind] =
+  block:
+    var config: set[DebugOutputKind] = {
+      dokOutput, dokError, dokCommand, dokRuntime
+    }
+
+    when defined shellNoDebugOutput:
+      config = config - {dokOutput}
+
+    when defined shellNoDebugError:
+      config = config - {dokError}
+
+    when defined shellNoDebugCommand:
+      config = config - {dokCommand}
+
+    when defined shellNoDebugRuntime:
+      config = config - {dokRuntime}
+
+    config
 
 proc stringify(cmd: NimNode): string
 proc iterateTree(cmds: NimNode): string
@@ -499,7 +512,7 @@ macro shellAssign*(cmd: untyped): untyped =
 
 when isMainModule:
   var myConfig: set[DebugOutputKind] = {dokError}
-  let (res, _) = shellVerbose(myConfig):
+  let (res, _) = shellVerbose:
     echo "test"
 
   echo "Result is: ", res

--- a/shell.nim
+++ b/shell.nim
@@ -230,7 +230,7 @@ proc concatCmds(cmds: seq[string], sep = " && "): string =
 
 proc asgnShell*(
   cmd: string,
-  debugConfig: set[DebugOutputKind]
+  debugConfig: set[DebugOutputKind] = getShellDebugConfig()
               ): tuple[output: string, exitCode: int] =
   ## wrapper around `execCmdEx`, which returns the output of the shell call
   ## as a string (stripped of `\n`)

--- a/shell.nim
+++ b/shell.nim
@@ -266,12 +266,15 @@ proc asgnShell*(
           echo "err> ", line
 
     pid.close()
-    result = (output: res, error: errorText.strip(), exitCode: exitCode)
+    result = (output: res, error: errorText, exitCode: exitCode)
   else:
     # prepend the NimScript called command by current directory
     let nscmd = &"cd {getCurrentDir()} && " & cmd
-    result = gorgeEx(nscmd, "", "")
-  result[0] = result[0].strip(chars = {'\n'})
+    let (res, code) = gorgeEx(nscmd, "", "")
+    result.output = res
+    result.exitCode = code
+  result.output = result.output.strip(chars = {'\n'})
+  result.error = result.error.strip(chars = {'\n'})
 
 proc execShell*(
   cmd: string,
@@ -496,19 +499,4 @@ macro shellAssign*(cmd: untyped): untyped =
     echo result.repr
 
 when isMainModule:
-  block:
-    let test = "test"
-    let (res, _) = shellVerbose:
-      echo ($test)
-
-    doAssert test == res
-
-  block:
-    let test = "test"
-    let (res, err, _) = shellVerboseErr:
-      echo ($test)
-      echo ($test) >&2
-
-    doAssert test == res
-    echo "[" & err & "]"
-    doAssert test == err
+  discard

--- a/shell.nim
+++ b/shell.nim
@@ -421,7 +421,6 @@ macro shellVerboseErr*(debugConfig, cmds: untyped): untyped =
     shellVerboseImpl `debugConfig`:
       `cmds`
 
-
 macro shellVerboseErr*(cmds: untyped): untyped =
   quote do:
     shellVerboseImpl defaultDebugConfig:
@@ -437,7 +436,6 @@ macro shellVerbose*(debugConfig, cmds: untyped): untyped =
       res.output = outStr & outErr
       res.code = code
       res
-
 
 macro shellVerbose*(cmds: untyped): untyped =
   quote do:
@@ -509,15 +507,3 @@ macro shellAssign*(cmd: untyped): untyped =
 
   when defined(debugShell):
     echo result.repr
-
-when isMainModule:
-  var myConfig: set[DebugOutputKind] = {dokError}
-  let (res, _) = shellVerbose:
-    echo "test"
-
-  echo "Result is: ", res
-
-  myConfig = {dokOutput}
-
-  let (res2, _) = shellVerbose(myConfig):
-    echo "test2"

--- a/shell.nimble
+++ b/shell.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.4"
+version       = "0.3.0"
 author        = "Vindaar"
 description   = "A Nim mini DSL to execute shell commands"
 license       = "MIT"

--- a/shell.nimble
+++ b/shell.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.3"
+version       = "0.2.4"
 author        = "Vindaar"
 description   = "A Nim mini DSL to execute shell commands"
 license       = "MIT"

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -311,3 +311,14 @@ suite "[shell]":
       echo Hello
     check res[1] != 0
     check res[0].startsWith("runBrokenCommand")
+
+  test "[shellVerboseErr] check stderr output":
+    block:
+      let test = "test"
+      let (res, err, _) = shellVerboseErr:
+        echo ($test)
+        echo ($test) >&2
+
+      doAssert test == res
+      echo "[" & err & "]"
+      doAssert test == err

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -313,12 +313,10 @@ suite "[shell]":
     check res[0].startsWith("runBrokenCommand")
 
   test "[shellVerboseErr] check stderr output":
-    block:
-      let test = "test"
-      let (res, err, _) = shellVerboseErr:
-        echo ($test)
-        echo ($test) >&2
+    let test = "test"
+    let (res, err, _) = shellVerboseErr:
+      echo ($test)
+      echo ($test) >&2
 
-      doAssert test == res
-      echo "[" & err & "]"
-      doAssert test == err
+    doAssert test == res
+    doAssert test == err


### PR DESCRIPTION
I added compile-time and runtime configuration options for conditionally disable printing of the command's output or command itself.

+ New compile-time pragmas: `shellNoDebugCommand`, `shellNoDebugOutput` that can disable output for command. 
+ New proc `setShellDebugConfig` for setting shell debug configuration at runtime. 
+ New enum `DebugOutputKind` for controlling what is being printed at runtime

----

I also want to add support for getting `stderr` and `stdout` *separately* instead of merging them into one string. I don't want to implement it in a way that would break existing code using this module (if I were to add third field to resulting tuple it would certainly break things). If you have any ideas I would be happy to use them as base for my implementation.

I haven't made any changes in README because I first want to implement several other things (support for separate `stderr` handling is one of them). 