### PR TITLE
RFC Throw exception or print error to stdout

### DIFF
--- a/README.org
+++ b/README.org
@@ -459,7 +459,9 @@ echo "Returned string: '", res, "' with exit code ", code
 
 Printing error directly into stdout is good solution for most of the
 use cases, but sometimes it is necessary to provide more sophisticated
-error handing - throwing exception when command failed.
+error handing - throwing exception when command failed. To switch to
+exceptions use ~-d:shellThrowException~. It will automatically disable
+all other output types in the default configuration.
 
 #+begin_src nim
 {.define(shellThrowException).}

--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@
 A mini Nim DSL to execute shell commands more conveniently.
 
 ** Usage
-With this macro you can simply write 
+With this macro you can simply write
 #+BEGIN_SRC nim
 shell:
   touch foo
@@ -18,14 +18,14 @@ execShell("mv foo bar")
 execShell("rm bar")
 #+END_SRC
 where =execShell= is a proc around =startProcess= for normal
-compilation and =gorgeEx= when using NimScript. 
+compilation and =gorgeEx= when using NimScript.
 
 Note: When using =NimScript= the given command is prepended by
-#+BEGIN_SRC 
+#+BEGIN_SRC
 &"cd {getCurrentDir()} && "
 #+END_SRC
 in order to switch the evaluation into the directory of the =shell=
-call. 
+call.
 The same is achieved on the compiled backend by the =poEvalCommand=
 argument to =startProcess=.
 
@@ -86,7 +86,7 @@ will work just as expected, echoing =Hallo= in the shell.
 =`=. For the old behavior compile with =-d:oldQuote=.
 
 Another important feature to make this library useful is quoting of
-Nim symbols. 
+Nim symbols.
 
 This is handled via parenthesis =()= (if you need to run something in
 a subshell unfortunately that will have to be done with an explicit
@@ -100,7 +100,7 @@ The simplest case would be:
 let name = "Vindaar"
 shell:
   echo Hello from ($name)
-#+END_SRC 
+#+END_SRC
 which will perform the call:
 #+BEGIN_SRC nim
 execShell(&"echo Hello from {name}!")
@@ -126,7 +126,7 @@ This can be done in several ways.
 let fname = "myimage"
 shell:
   convert ($fname).png ($fname).jpg
-#+END_SRC 
+#+END_SRC
 Note that this is a special case. Continuing after a =()= quote
 without literal strings will only work for dot expressions. For
 instance:
@@ -191,7 +191,7 @@ the most predictable behavior. But that was a bad idea from my side!
 If you need spaces, simply put it outside the =()= and use a space!
 
 The =doAssert= below is to be understood in the context of the =shell=
-macro. To summarize the above then: 
+macro. To summarize the above then:
 #+BEGIN_SRC nim
 let outfile = "myoutput.txt"
 doAssert ("--out="$outfile) == &"--out={outfile}" # <- without space, ident after
@@ -309,7 +309,7 @@ This macro can also be used in NimScript! Instead of =execCmdEx= the
 ** Known issues
 
 Certain things unfortunately *have* to go into quotation marks. As
-seen in the =one= example above, the simple =..= is not allowed. 
+seen in the =one= example above, the simple =..= is not allowed.
 
 Variable assignments in the shell need to be handed via a string
 literal:
@@ -387,7 +387,106 @@ according to the expansion above.
 ** Debugging
 In order to see what's going on, you can either compile your program
 with the =-d:debugShell= flag, which will then echo the rewritten
-commands during compilation. 
+commands during compilation.
 Alternatively in order to avoid calling the commands immediately, you
 may use the =shellEcho= macro instead. It simply echoes the commands
 that would otherwise be run.
+
+** Error reporting
+  :PROPERTIES:
+  :header-args:nim: :exports both :results scalar
+  :END:
+
+By default ~shell~ prints output messages to stdout:
+
+#+BEGIN_SRC nim
+import shell
+
+shell:
+  ls
+#+END_SRC
+
+#+RESULTS:
+: shellCmd: ls
+: shell> nim.cfg
+: shell> README.org
+: shell> shell
+: shell> shell.nim
+: shell> shell.nim.bin
+: shell> shell.nimble
+: shell> tests
+
+What is printed to stdout can be configured by using defines:
+
+- ~shellNoDebugOutput~ :: Do not print command output
+- ~shellNoDebugError~ :: Do not print error output
+- ~shellNoDebugCommand~ :: Do not print command being executed
+- ~shellNoDebugRuntime~ :: When error occurs do not print failed command
+
+By default the are disabled - to enable use either ~-d:shellNoDebug*~
+or use ~{.define(shellNoDebug*).}~ pragma
+
+#+BEGIN_SRC nim
+{.define(shellNoDebugOutput).}
+
+import shell
+
+shell:
+  ls
+#+END_SRC
+
+#+RESULTS:
+: shellCmd: ls
+
+Default ~shellVerbose~ command combines stderr and stdout into single
+result. Tot get =stdout=, =stderr= and return code separately use
+~shellVerboseErr~. Both of these templates have an overload that takes
+~set[DebugOutputKind]~ to control printing settings:
+
+#+BEGIN_SRC nim
+import shell
+
+let (res, err, code) = shellVerboseErr {dokCommand}:
+  echo "test"
+
+echo "Returned string: '", res, "' with exit code ", code
+
+#+END_SRC
+
+#+RESULTS[f131ce6c1b15aaf206f997569ec95ff8564a05dc]:
+: shellCmd: echo test
+: Returned string: 'test' with exit code 0
+
+Printing error directly into stdout is good solution for most of the
+use cases, but sometimes it is necessary to provide more sophisticated
+error handing - throwing exception when command failed.
+
+#+begin_src nim
+{.define(shellThrowException).}
+
+import shell, strutils
+
+try:
+  shell:
+    ls -l
+    ls -z
+except ShellExecError:
+  let e = cast[ShellExecError](getCurrentException())
+  echo e.msg # Error message describing what happened
+  echo "command was: ", e.cmd # Original command string
+  assert e.cmd == "ls -z"
+  echo "return code: ", e.retcode # Return code
+  echo "error outpt: "
+  for l in e.errstr.split('\n'): # Stderr from the command
+    echo "  ", l
+#+end_src
+
+#+RESULTS:
+: Command ls -z exited with non-zero code
+: command was: ls -z
+: return code: 2
+: error outpt:
+:   ls: invalid option -- 'z'
+:   Try 'ls --help' for more information.
+
+On command failure ~ShellExecError~

--- a/README.org
+++ b/README.org
@@ -453,7 +453,7 @@ echo "Returned string: '", res, "' with exit code ", code
 
 #+END_SRC
 
-#+RESULTS[f131ce6c1b15aaf206f997569ec95ff8564a05dc]:
+#+RESULTS:
 : shellCmd: echo test
 : Returned string: 'test' with exit code 0
 

--- a/README.org
+++ b/README.org
@@ -475,6 +475,7 @@ except ShellExecError:
   echo "command was: ", e.cmd # Original command string
   assert e.cmd == "ls -z"
   echo "return code: ", e.retcode # Return code
+  echo "regular out: ", e.outstr # Stdout from command
   echo "error outpt: "
   for l in e.errstr.split('\n'): # Stderr from the command
     echo "  ", l
@@ -484,6 +485,7 @@ except ShellExecError:
 : Command ls -z exited with non-zero code
 : command was: ls -z
 : return code: 2
+: regular out:
 : error outpt:
 :   ls: invalid option -- 'z'
 :   Try 'ls --help' for more information.

--- a/README.org
+++ b/README.org
@@ -420,8 +420,8 @@ What is printed to stdout can be configured by using defines:
 - ~shellNoDebugCommand~ :: Do not print command being executed
 - ~shellNoDebugRuntime~ :: When error occurs do not print failed command
 
-By default the are disabled - to enable use either ~-d:shellNoDebug*~
-or use ~{.define(shellNoDebug*).}~ pragma
+By default these are disabled - to enable use either
+~-d:shellNoDebug*~ or use the ~{.define(shellNoDebug*).}~ pragma
 
 #+BEGIN_SRC nim :exports both :results scalar
 {.define(shellNoDebugOutput).}
@@ -435,10 +435,10 @@ shell:
 #+RESULTS:
 : shellCmd: ls
 
-Default ~shellVerbose~ command combines stderr and stdout into single
-result. Tot get =stdout=, =stderr= and return code separately use
-~shellVerboseErr~. Both of these templates have an overload that takes
-~set[DebugOutputKind]~ to control printing settings:
+The default ~shellVerbose~ command combines stderr and stdout into
+single result. To get =stdout=, =stderr= and return code separately
+use ~shellVerboseErr~. Both of these templates have an overload that
+takes ~set[DebugOutputKind]~ to control printing settings:
 
 #+BEGIN_SRC nim :exports both :results scalar
 import shell
@@ -454,7 +454,7 @@ echo "Returned string: '", res, "' with exit code ", code
 : shellCmd: echo test
 : Returned string: 'test' with exit code 0
 
-Printing error directly into stdout is good solution for most of the
+Printing errors directly into stdout is good solution for most of the
 use cases, but sometimes it is necessary to provide more sophisticated
 error handing - throwing exception when command failed. To switch to
 exceptions use ~-d:shellThrowException~. It will automatically disable
@@ -490,4 +490,4 @@ except ShellExecError:
 :   ls: invalid option -- 'z'
 :   Try 'ls --help' for more information.
 
-On command failure ~ShellExecError~
+On command failure ~ShellExecError~ is raised.

--- a/README.org
+++ b/README.org
@@ -511,6 +511,7 @@ except ShellExecError:
   let e = cast[ShellExecError](getCurrentException())
   echo e.msg # Error message describing what happened
   echo "command was: ", e.cmd # Original command string
+  echo "exec direct: ", e.cwd # 
   echo "return code: ", e.retcode # Return code
   echo "regular out: \n====\n", e.outstr # Stdout from command
   echo "====\nerror outpt: \n====\n", e.errstr # Stderr from the command
@@ -520,18 +521,13 @@ except ShellExecError:
 #+begin_example
 Command ngspice -b /tmp/ngpsice-simulation/zzz.netkRs8jE exited with non-zero code
 command was: ngspice -b /tmp/ngpsice-simulation/zzz.netkRs8jE
+exec direct: /home/test/workspace/git-sandbox/shell
 return code: 1
-regular out:
+regular out: 
 ====
-Circuit: simulating document
 
-Error on line 53 :
-  d 7 6 1n4148
-device already exists, existing one being used
 ====
-error outpt:
+error outpt: 
 ====
-ngspice stopped due to error, no simulation run!
-
-ERROR: fatal error in ngspice, exit(1)
+/tmp/ngpsice-simulation/zzz.netkRs8jE: No such file or directory
 #+end_example

--- a/README.org
+++ b/README.org
@@ -423,7 +423,7 @@ What is printed to stdout can be configured by using defines:
 By default the are disabled - to enable use either ~-d:shellNoDebug*~
 or use ~{.define(shellNoDebug*).}~ pragma
 
-#+BEGIN_SRC nim
+#+BEGIN_SRC nim :exports both :results scalar
 {.define(shellNoDebugOutput).}
 
 import shell

--- a/README.org
+++ b/README.org
@@ -393,13 +393,10 @@ may use the =shellEcho= macro instead. It simply echoes the commands
 that would otherwise be run.
 
 ** Error reporting
-  :PROPERTIES:
-  :header-args:nim: :exports both :results scalar
-  :END:
 
 By default ~shell~ prints output messages to stdout:
 
-#+BEGIN_SRC nim
+#+BEGIN_SRC nim :exports both :results scalar
 import shell
 
 shell:
@@ -443,7 +440,7 @@ result. Tot get =stdout=, =stderr= and return code separately use
 ~shellVerboseErr~. Both of these templates have an overload that takes
 ~set[DebugOutputKind]~ to control printing settings:
 
-#+BEGIN_SRC nim
+#+BEGIN_SRC nim :exports both :results scalar
 import shell
 
 let (res, err, code) = shellVerboseErr {dokCommand}:
@@ -463,7 +460,7 @@ error handing - throwing exception when command failed. To switch to
 exceptions use ~-d:shellThrowException~. It will automatically disable
 all other output types in the default configuration.
 
-#+begin_src nim
+#+begin_src nim :exports both :results scalar
 {.define(shellThrowException).}
 
 import shell, strutils

--- a/README.org
+++ b/README.org
@@ -436,9 +436,10 @@ shell:
 : shellCmd: ls
 
 The default ~shellVerbose~ command combines stderr and stdout into
-single result. To get =stdout=, =stderr= and return code separately
-use ~shellVerboseErr~. Both of these templates have an overload that
-takes ~set[DebugOutputKind]~ to control printing settings:
+single result. To get =stdout=, =stderr= and the return code
+separately use ~shellVerboseErr~. Both of these templates have an
+overload that takes ~set[DebugOutputKind]~ to control printing
+settings:
 
 #+BEGIN_SRC nim :exports both :results scalar
 import shell
@@ -456,9 +457,10 @@ echo "Returned string: '", res, "' with exit code ", code
 
 Printing errors directly into stdout is good solution for most of the
 use cases, but sometimes it is necessary to provide more sophisticated
-error handing - throwing exception when command failed. To switch to
-exceptions use ~-d:shellThrowException~. It will automatically disable
-all other output types in the default configuration.
+error handing - throwing an exception when the command failed. To
+switch to exceptions use ~-d:shellThrowException~. It will
+automatically disable all other output types in the default
+configuration.
 
 #+begin_src nim :exports both :results scalar
 {.define(shellThrowException).}
@@ -491,3 +493,45 @@ except ShellExecError:
 :   Try 'ls --help' for more information.
 
 On command failure ~ShellExecError~ is raised.
+
+Note that some commands output error messages into ~stdout~ rather
+than into ~stderr~ - it might be necessary to check both. In this
+particular example content of the ~stderr~ is largely meaningless:
+actual reason for error was printed into ~stdout~.
+
+#+begin_src nim :exports both :results scalar
+{.define(shellThrowException).}
+
+import shell, strutils
+
+try:
+  shell:
+    ngspice -b "/tmp/ngpsice-simulation/zzz.netkRs8jE"
+except ShellExecError:
+  let e = cast[ShellExecError](getCurrentException())
+  echo e.msg # Error message describing what happened
+  echo "command was: ", e.cmd # Original command string
+  echo "return code: ", e.retcode # Return code
+  echo "regular out: \n====\n", e.outstr # Stdout from command
+  echo "====\nerror outpt: \n====\n", e.errstr # Stderr from the command
+#+end_src
+
+#+RESULTS:
+#+begin_example
+Command ngspice -b /tmp/ngpsice-simulation/zzz.netkRs8jE exited with non-zero code
+command was: ngspice -b /tmp/ngpsice-simulation/zzz.netkRs8jE
+return code: 1
+regular out:
+====
+Circuit: simulating document
+
+Error on line 53 :
+  d 7 6 1n4148
+device already exists, existing one being used
+====
+error outpt:
+====
+ngspice stopped due to error, no simulation run!
+
+ERROR: fatal error in ngspice, exit(1)
+#+end_example

--- a/shell.nim
+++ b/shell.nim
@@ -24,6 +24,7 @@ type
 type
   ShellExecError* = ref object of CatchableError
     cmd*: string ## Command that returned non-zero exit code
+    cwd*: string ## Absolute path of initial command execution directory
     retcode*: int ## Exit code
     errstr*: string ## Stderr for command
     outstr*: string ## Stdout for command
@@ -310,6 +311,7 @@ proc execShell*(
   if dokCommand in debugConfig:
     echo "shellCmd: ", cmd
 
+  let cwd = getCurrentDir()
   result = asgnShell(cmd, debugConfig)
 
   if dokOutput in debugConfig:
@@ -325,6 +327,7 @@ proc execShell*(
       raise ShellExecError(
         msg: "Command " & cmd & " exited with non-zero code",
         cmd: cmd,
+        cwd: cwd,
         retcode: result.exitCode,
         errstr: result.error,
         outstr: result.output

--- a/shell.nim
+++ b/shell.nim
@@ -22,10 +22,10 @@ type
 
 
 type
-  ShellExecError = ref object of CatchableError
-    cmd: string ## Command that returned non-zero exit code
-    retcode: int ## Exit code
-    errstr: string ## Stdout for command
+  ShellExecError* = ref object of CatchableError
+    cmd*: string ## Command that returned non-zero exit code
+    retcode*: int ## Exit code
+    errstr*: string ## Stdout for command
 
 const defaultDebugConfig: set[DebugOutputKind] =
   block:
@@ -306,10 +306,6 @@ proc execShell*(
               ): tuple[output, error: string, exitCode: int] =
   ## wrapper around `asgnShell`, which calls the commands and handles
   ## return values.
-
-  # IDEA split command by space and layout it line-by-line if it is
-  # too long to fit on one line. This will increase readability of
-  # debug output
   if dokCommand in debugConfig:
     echo "shellCmd: ", cmd
 
@@ -528,16 +524,3 @@ macro shellAssign*(cmd: untyped): untyped =
 
   when defined(debugShell):
     echo result.repr
-
-when isMainModule:
-  try:
-    shell:
-      ls -z
-  except ShellExecError:
-    let e = cast[ShellExecError](getCurrentException())
-    echo e.msg
-    echo "command was: ", e.cmd
-    echo "return code: ", e.retcode
-    echo "error outpt: "
-    for l in e.errstr.split('\n'):
-      echo "  ", l

--- a/shell.nim
+++ b/shell.nim
@@ -434,6 +434,15 @@ macro shellVerboseImpl*(debugConfig, cmds: untyped): untyped =
 
 
 macro shellVerboseErr*(debugConfig, cmds: untyped): untyped =
+  ## Run shell command, return `(stdout, stderr, code)`. `debugConfig`
+  ## is an configuration for shell execution
+  runnableExamples:
+    let (res, err, code) = shellVerboseErr {dokCommand}:
+      echo "test"
+
+    assert res == "test"
+    assert code == 0
+
   quote do:
     shellVerboseImpl `debugConfig`:
       `cmds`

--- a/shell.nim
+++ b/shell.nim
@@ -25,7 +25,8 @@ type
   ShellExecError* = ref object of CatchableError
     cmd*: string ## Command that returned non-zero exit code
     retcode*: int ## Exit code
-    errstr*: string ## Stdout for command
+    errstr*: string ## Stderr for command
+    outstr*: string ## Stdout for command
 
 const defaultDebugConfig: set[DebugOutputKind] =
   block:
@@ -325,7 +326,8 @@ proc execShell*(
         msg: "Command " & cmd & " exited with non-zero code",
         cmd: cmd,
         retcode: result.exitCode,
-        errstr: result.error
+        errstr: result.error,
+        outstr: result.output
       )
 
 proc flattenCmds(cmds: NimNode): NimNode =

--- a/shell.nim
+++ b/shell.nim
@@ -383,9 +383,9 @@ proc nilOrQuote(cmd: string): NimNode =
 macro shellVerboseImpl*(debugConfig, cmds: untyped): untyped =
   ## a mini DSL to write shell commands in Nim. Some constructs are not
   ## implemented. If in doubt, put (parts of) the command into " "
-  ## The command is echoed before it is run. It is prefixed by `shellCmd: `.
+  ## The command is echoed before it is run. It is prefixed by `shellCmd:`.
   ## If there is output, the output is echoed. Each successive line of the
-  ## output is prefixed by `shell> `.
+  ## output is prefixed by `shell>`.
   ## If multiple commands are run in succession (i.e. multiple statements in
   ## the macro body) and one command returns a non-zero exit code, the following
   ## commands will not be run. Instead a warning message will be shown.

--- a/shell.nimble
+++ b/shell.nimble
@@ -12,6 +12,7 @@ requires "nim >= 0.19.0"
 
 task test, "executes the tests":
   exec "nim c -d:debugShell -r tests/tShell.nim"
+  exec "nim c -r tests/tException.nim"
   # execute using NimScript as well
   exec "nim e -d:debugShell -r tests/tNimScript.nims"
   # and execute PWD test, by running the nims file in another dir,

--- a/shell.nimble
+++ b/shell.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.0"
+version       = "0.4.0"
 author        = "Vindaar"
 description   = "A Nim mini DSL to execute shell commands"
 license       = "MIT"

--- a/tests/tException.nim
+++ b/tests/tException.nim
@@ -1,0 +1,23 @@
+{.define(shellThrowException).}
+
+import ../shell
+import unittest
+import strutils
+
+suite "[shell]":
+  test "[exception] throw on invalid command":
+    try:
+      shell:
+        ls -l
+        ls -z
+    except ShellExecError:
+      let e = cast[ShellExecError](getCurrentException())
+      echo e.msg
+      echo "command was: ", e.cmd
+      assert e.cmd == "ls -z"
+      echo "return code: ", e.retcode
+      echo "error outpt: "
+      for l in e.errstr.split('\n'):
+        echo "  ", l
+    except:
+      assert false, "Execution must throw exception `ShellExecError`"

--- a/tests/tException.nim
+++ b/tests/tException.nim
@@ -15,6 +15,7 @@ suite "[shell]":
       echo e.msg
       echo "command was: ", e.cmd
       assert e.cmd == "ls -z"
+      echo "executed in directory:", e.cwd
       echo "return code: ", e.retcode
       echo "error outpt: "
       for l in e.errstr.split('\n'):


### PR DESCRIPTION
Add support for throwing exception on invalid command input instead of
printing error to stdout. This opens possibilities for more sophisticated error handling.

New behavior is enabled via `-d:shellThrowException` - already existing code will not be affected.