### PR TITLE
Better handle quoting of complicated expressions

### DIFF
--- a/shell.nim
+++ b/shell.nim
@@ -196,7 +196,8 @@ proc stringify(cmd: NimNode): string =
     result = cmd.strVal
   of nnkIntLit, nnkFloatLit:
     result = cmd.repr
-  of nnkVarTy:
+  of nnkVarTy, nnkMutableTy:
+    # `nnkMutableTy` required for https://github.com/nim-lang/Nim/issues/15751
     result = handleVarTy(cmd)
   of nnkInfix:
     result = recurseInfix(cmd)

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -63,7 +63,6 @@ suite "[shell]":
     do:
       "./reconstruction Run123 --out"
 
-
   test "[shell] single cmd w/ tripleStrLit to escape \" ":
     checkShell:
       ./reconstruction Run123 """--out="test.h5""""
@@ -247,6 +246,20 @@ suite "[shell]":
       ./test ("--in="$(path.extractFilename))
     do:
       &"./test --in={path.extractFilename}"
+
+  test "[shell] quoting a Nim expression, prepending and appending to it":
+    let name = "foo"
+    checkShell:
+      Rscript -e ("rmarkdown::render('"$name"')")
+    do:
+      &"Rscript -e rmarkdown::render('foo')"
+
+  test "[shell] quoting a Nim expression, prepending and appending to it, literal string":
+    let name = "foo"
+    checkShell:
+      Rscript -e ("\"rmarkdown::render('"$name"""')"""")
+    do:
+      &"Rscript -e \"rmarkdown::render('foo')\""
 
   test "[shell] quoting a Nim expression without anything else":
     let myCmd = "runMe"


### PR DESCRIPTION
A usage example of @lf-araujo made me rethink the implementation of quoting Nim identifiers.

Specifically being able to have a literal string before and after a Nim identifier to quote within parentheses.


This means the following works now. Note though, that it's really ugly, in part because we abuse call strings and cannot insert a literal `"` by using `\"` in the latter part of the string. For such use cases it _really_ is a better idea to simply create the argument as using normal string interpolation before hand.
```nim
    let name = "foo"
    checkShell:
      Rscript -e ("\"rmarkdown::render('"$name"""')"""")
    do:
      &"Rscript -e \"rmarkdown::render('foo')\""
```

So better do:
```nim
    let name = "foo"
    let arg = &"\"rmarkdown::render('{name}')\""
    checkShell:
      Rscript -e ($arg)
    do:
      &"Rscript -e \"rmarkdown::render('foo')\""
```

but it's good that this works now, specifically for simpler cases like:

```nim
  let foo = "foo"
  checkShell:
    someCommand ("baz"$foo"bar)
  do:
    "someCommand bazfoobar"
```