### PR TITLE
Fix shell assign regression, closes #12

### DIFF
--- a/shell.nim
+++ b/shell.nim
@@ -551,8 +551,9 @@ macro shellAssign*(cmd: untyped): untyped =
   let cmds = nnkIdentDefs.newTree(cmd[0][1])
   let shCmd = genShellCmds(cmds)[0]
 
+  let qCmd = nilOrQuote(shCmd)
   result = quote do:
-    `nimSym` = asgnShell(`shCmd`)[0]
+    `nimSym` = asgnShell(`qCmd`)[0]
 
   when defined(debugShell):
     echo result.repr

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -284,6 +284,14 @@ suite "[shell]":
       # test is super flaky on travis. Often thee 10 is missing?!
       check res == "8\n9\n10"
 
+  test "[shellAssign] assigning output from shell to a variable while quoting a Nim var":
+    var res = ""
+    let name1 = "Lucian"
+    let name2 = "Markus"
+    shellAssign:
+      res = echo "Hello " ($name1) "and" ($name2)
+    check res == "Hello Lucian and Markus"
+
   test "[shell] real time output":
     shell:
       "for f in 1 2 3; do echo $f; sleep 1; done"


### PR DESCRIPTION
Fixes the handling of quoted identifiers when using `shellAssign`, closes #12.