### PR TITLE
Allow custom process options, change `shellVerbose` internals

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,8 +1,16 @@
 * v0.4.3
 - replace travis CI by Github Actions (now includes Windows and OSX
   testing)
+  - windows support is only partial. =one= and =pipe= appear to be
+    broken
 - change =shellVerboseImpl=, =shellVerbose= internals
-- allow to customize the process options, which are handed to =startProcess=
+- allow to customize the process options, which are handed to
+  =startProcess=
+- command not found on windows is an =OSError=, which we catch and
+  turn into an error code
+- do not close error stream manually anymore (should not be done
+  according to Nim docs of =osproc.errorStream=)
+
 * v0.4.2
 - fix =shellAssign= to allow quoting of Nim variables
 * v0.4.1

--- a/changelog.org
+++ b/changelog.org
@@ -1,2 +1,9 @@
+* v0.4.3
+- replace travis CI by Github Actions (now includes Windows and OSX
+  testing)
+- change =shellVerboseImpl=, =shellVerbose= internals
+- allow to customize the process options, which are handed to =startProcess=
+* v0.4.2
+- fix =shellAssign= to allow quoting of Nim variables
 * v0.4.1
 - improve handling of complicated quoting expressions

--- a/docs/nimdoc.out.css
+++ b/docs/nimdoc.out.css
@@ -14,6 +14,9 @@ Modified by Boyd Greenfield and narimiran
   --primary-background: #fff;
   --secondary-background: ghostwhite;
   --third-background: #e8e8e8;
+  --info-background: #50c050;
+  --warning-background: #c0a000;
+  --error-background: #e04040;
   --border: #dde;
   --text: #222;
   --anchor: #07b;
@@ -39,6 +42,9 @@ Modified by Boyd Greenfield and narimiran
   --primary-background: #171921;
   --secondary-background: #1e202a;
   --third-background: #2b2e3b;
+  --info-background: #008000;
+  --warning-background: #807000;
+  --error-background: #c03000;
   --border: #0e1014;
   --text: #fff;
   --anchor: #8be9fd;
@@ -608,6 +614,34 @@ table.borderless td, table.borderless th {
   /* Override padding for "table.docutils td" with "! important".
      The right padding separates the table cells. */
   padding: 0 0.5em 0 0 !important; }
+
+.admonition {
+    padding: 0.3em;
+    background-color: var(--secondary-background);
+    border-left: 0.4em solid #7f7f84;
+    margin-bottom: 0.5em;
+    -webkit-box-shadow: 0 5px 8px -6px rgba(0,0,0,.2);
+       -moz-box-shadow: 0 5px 8px -6px rgba(0,0,0,.2);
+            box-shadow: 0 5px 8px -6px rgba(0,0,0,.2);
+}
+.admonition-info {
+    border-color: var(--info-background);
+}
+.admonition-info-text {
+    color: var(--info-background);
+}
+.admonition-warning {
+    border-color: var(--warning-background);
+}
+.admonition-warning-text {
+    color: var(--warning-background);
+}
+.admonition-error {
+    border-color: var(--error-background);
+}
+.admonition-error-text {
+    color: var(--error-background);
+}
 
 .first {
   /* Override more specific margin styles with "! important". */

--- a/docs/shell.html
+++ b/docs/shell.html
@@ -113,15 +113,17 @@ window.addEventListener('DOMContentLoaded', main);
   <a class="reference reference-toplevel" href="#12" id="62">Procs</a>
   <ul class="simple simple-toc-section">
       <ul class="simple nested-toc-section">asgnShell
-      <li><a class="reference" href="#asgnShell%2Cstring%2Cset%5BDebugOutputKind%5D"
-    title="asgnShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig): tuple[
-    output, error: string, exitCode: int]">asgnShell,<wbr>string,<wbr>set[DebugOutputKind]</a></li>
+      <li><a class="reference" href="#asgnShell%2Cstring%2Cset%5BDebugOutputKind%5D%2Cset%5BProcessOption%5D"
+    title="asgnShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig;
+          options: set[ProcessOption] = defaultProcessOptions): tuple[
+    output, error: string, exitCode: int]">asgnShell,<wbr>string,<wbr>set[DebugOutputKind],<wbr>set[ProcessOption]</a></li>
 
   </ul>
   <ul class="simple nested-toc-section">execShell
-      <li><a class="reference" href="#execShell%2Cstring%2Cset%5BDebugOutputKind%5D"
-    title="execShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig): tuple[
-    output, error: string, exitCode: int]">execShell,<wbr>string,<wbr>set[DebugOutputKind]</a></li>
+      <li><a class="reference" href="#execShell%2Cstring%2Cset%5BDebugOutputKind%5D%2Cset%5BProcessOption%5D"
+    title="execShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig;
+          options: set[ProcessOption] = defaultProcessOptions): tuple[
+    output, error: string, exitCode: int]">execShell,<wbr>string,<wbr>set[DebugOutputKind],<wbr>set[ProcessOption]</a></li>
 
   </ul>
 
@@ -130,16 +132,10 @@ window.addEventListener('DOMContentLoaded', main);
 <li>
   <a class="reference reference-toplevel" href="#17" id="67">Macros</a>
   <ul class="simple simple-toc-section">
-      <li><a class="reference" href="#shellVerboseImpl.m%2Cuntyped%2Cuntyped"
-    title="shellVerboseImpl(debugConfig, cmds: untyped): untyped">shellVerboseImpl</a></li>
-  <li><a class="reference" href="#shellVerboseErr.m%2Cuntyped%2Cuntyped"
-    title="shellVerboseErr(debugConfig, cmds: untyped): untyped">shellVerboseErr</a></li>
-  <li><a class="reference" href="#shellVerboseErr.m%2Cuntyped"
-    title="shellVerboseErr(cmds: untyped): untyped">shellVerboseErr</a></li>
-  <li><a class="reference" href="#shellVerbose.m%2Cuntyped%2Cuntyped"
-    title="shellVerbose(debugConfig, cmds: untyped): untyped">shellVerbose</a></li>
-  <li><a class="reference" href="#shellVerbose.m%2Cuntyped"
-    title="shellVerbose(cmds: untyped): untyped">shellVerbose</a></li>
+      <li><a class="reference" href="#shellVerbose.m%2Cvarargs%5Buntyped%5D"
+    title="shellVerbose(args: varargs[untyped]): untyped">shellVerbose</a></li>
+  <li><a class="reference" href="#shellVerboseErr.m%2Cvarargs%5Buntyped%5D"
+    title="shellVerboseErr(args: varargs[untyped]): untyped">shellVerboseErr</a></li>
   <li><a class="reference" href="#shell.m%2Cuntyped"
     title="shell(cmds: untyped): untyped">shell</a></li>
   <li><a class="reference" href="#shellEcho.m%2Cuntyped"
@@ -174,9 +170,9 @@ class="link-seesrc" target="_blank">Source</a>
 
 
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L17"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L18"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L17" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L18" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
 <a id="ShellExecError"></a>
@@ -201,9 +197,10 @@ class="link-seesrc" target="_blank">Source</a>
 <div class="section" id="12">
 <h1><a class="toc-backref" href="#12">Procs</a></h1>
 <dl class="item">
-<a id="asgnShell,string,set[DebugOutputKind]"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#asgnShell%2Cstring%2Cset%5BDebugOutputKind%5D"><span class="Identifier">asgnShell</span></a><span class="Other">(</span><span class="Identifier">cmd</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
-               <span class="Identifier">debugConfig</span><span class="Other">:</span> <span class="Identifier">set</span><span class="Other">[</span><a href="shell.html#DebugOutputKind"><span class="Identifier">DebugOutputKind</span></a><span class="Other">]</span> <span class="Other">=</span> <span class="Identifier">defaultDebugConfig</span><span class="Other">)</span><span class="Other">:</span> <span class="Keyword">tuple</span><span class="Other">[</span>
+<a id="asgnShell,string,set[DebugOutputKind],set[ProcessOption]"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#asgnShell%2Cstring%2Cset%5BDebugOutputKind%5D%2Cset%5BProcessOption%5D"><span class="Identifier">asgnShell</span></a><span class="Other">(</span><span class="Identifier">cmd</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
+               <span class="Identifier">debugConfig</span><span class="Other">:</span> <span class="Identifier">set</span><span class="Other">[</span><a href="shell.html#DebugOutputKind"><span class="Identifier">DebugOutputKind</span></a><span class="Other">]</span> <span class="Other">=</span> <span class="Identifier">defaultDebugConfig</span><span class="Other">;</span>
+               <span class="Identifier">options</span><span class="Other">:</span> <span class="Identifier">set</span><span class="Other">[</span><span class="Identifier">ProcessOption</span><span class="Other">]</span> <span class="Other">=</span> <span class="Identifier">defaultProcessOptions</span><span class="Other">)</span><span class="Other">:</span> <span class="Keyword">tuple</span><span class="Other">[</span>
     <span class="Identifier">output</span><span class="Other">,</span> <span class="Identifier">error</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">exitCode</span><span class="Other">:</span> <span class="Identifier">int</span><span class="Other">]</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma">
     <span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ExecIOEffect</span><span class="Other">,</span> <span class="Identifier">ReadEnvEffect</span><span class="Other">,</span>
     <span class="Identifier">RootEffect</span><span class="Other">,</span> <span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
@@ -211,14 +208,15 @@ class="link-seesrc" target="_blank">Source</a>
 
 wrapper around <tt class="docutils literal"><span class="pre">execCmdEx</span></tt>, which returns the output of the shell call as a string (stripped of <tt class="docutils literal"><span class="pre">n</span></tt>)
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L258"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L259"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L258" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L259" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
-<a id="execShell,string,set[DebugOutputKind]"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#execShell%2Cstring%2Cset%5BDebugOutputKind%5D"><span class="Identifier">execShell</span></a><span class="Other">(</span><span class="Identifier">cmd</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
-               <span class="Identifier">debugConfig</span><span class="Other">:</span> <span class="Identifier">set</span><span class="Other">[</span><a href="shell.html#DebugOutputKind"><span class="Identifier">DebugOutputKind</span></a><span class="Other">]</span> <span class="Other">=</span> <span class="Identifier">defaultDebugConfig</span><span class="Other">)</span><span class="Other">:</span> <span class="Keyword">tuple</span><span class="Other">[</span>
+<a id="execShell,string,set[DebugOutputKind],set[ProcessOption]"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#execShell%2Cstring%2Cset%5BDebugOutputKind%5D%2Cset%5BProcessOption%5D"><span class="Identifier">execShell</span></a><span class="Other">(</span><span class="Identifier">cmd</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">;</span>
+               <span class="Identifier">debugConfig</span><span class="Other">:</span> <span class="Identifier">set</span><span class="Other">[</span><a href="shell.html#DebugOutputKind"><span class="Identifier">DebugOutputKind</span></a><span class="Other">]</span> <span class="Other">=</span> <span class="Identifier">defaultDebugConfig</span><span class="Other">;</span>
+               <span class="Identifier">options</span><span class="Other">:</span> <span class="Identifier">set</span><span class="Other">[</span><span class="Identifier">ProcessOption</span><span class="Other">]</span> <span class="Other">=</span> <span class="Identifier">defaultProcessOptions</span><span class="Other">)</span><span class="Other">:</span> <span class="Keyword">tuple</span><span class="Other">[</span>
     <span class="Identifier">output</span><span class="Other">,</span> <span class="Identifier">error</span><span class="Other">:</span> <span class="Identifier">string</span><span class="Other">,</span> <span class="Identifier">exitCode</span><span class="Other">:</span> <span class="Identifier">int</span><span class="Other">]</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma">
     <span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">OSError</span><span class="Other">,</span> <span class="Identifier">Exception</span><span class="Other">,</span> <span class="Identifier">IOError</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Identifier">ExecIOEffect</span><span class="Other">,</span> <span class="Identifier">ReadEnvEffect</span><span class="Other">,</span>
     <span class="Identifier">RootEffect</span><span class="Other">,</span> <span class="Identifier">ReadIOEffect</span><span class="Other">,</span> <span class="Identifier">TimeEffect</span><span class="Other">,</span> <span class="Identifier">WriteIOEffect</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
@@ -226,9 +224,9 @@ class="link-seesrc" target="_blank">Source</a>
 
 wrapper around <tt class="docutils literal"><span class="pre">asgnShell</span></tt>, which calls the commands and handles return values.
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L323"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L326"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L323" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L326" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
 
@@ -236,34 +234,46 @@ class="link-seesrc" target="_blank">Source</a>
 <div class="section" id="17">
 <h1><a class="toc-backref" href="#17">Macros</a></h1>
 <dl class="item">
-<a id="shellVerboseImpl.m,untyped,untyped"></a>
-<dt><pre><span class="Keyword">macro</span> <a href="#shellVerboseImpl.m%2Cuntyped%2Cuntyped"><span class="Identifier">shellVerboseImpl</span></a><span class="Other">(</span><span class="Identifier">debugConfig</span><span class="Other">,</span> <span class="Identifier">cmds</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
+<a id="shellVerbose.m,varargs[untyped]"></a>
+<dt><pre><span class="Keyword">macro</span> <a href="#shellVerbose.m%2Cvarargs%5Buntyped%5D"><span class="Identifier">shellVerbose</span></a><span class="Other">(</span><span class="Identifier">args</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Identifier">untyped</span><span class="Other">]</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
 <dd>
 
-<p>A mini DSL to write shell commands in Nim. Some constructs are not implemented. If in doubt, put (parts of) the command into <tt class="docutils literal"><span class="pre">&quot; &quot;</span></tt> The command is echoed before it is run. It is prefixed by</p>
-<p><pre class="listing">
-shellCmd:
-</pre> If there is output, the output is echoed. Each successive line of the output is prefixed by</p>
-<p><pre class="listing">
-shell&gt;
-</pre> If multiple commands are run in succession (i.e. multiple statements in the macro body) and one command returns a non-zero exit code, the following commands will not be run. Instead a warning message will be shown.</p>
-<p>For usage with NimScript the output can only be echoed after the call has finished.</p>
-<p>The macro returns a tuple of:</p>
-<ul class="simple"><li><tt class="docutils literal"><span class="pre">output: string</span></tt> &lt;- output of the shell command to stdout</li>
+<p>See the <tt class="docutils literal"><span class="pre">shell</span></tt> macro below for a general explanation.</p>
+<p>This macro differs from <tt class="docutils literal"><span class="pre">shell</span></tt> in as such that it</p>
+<ol class="simple"><li>returns a tuple of</li>
+</ol>
+<blockquote><p><ul class="simple"><li><tt class="docutils literal"><span class="pre">output: string</span></tt> &lt;- output of the shell command to stdout</li>
 <li><tt class="docutils literal"><span class="pre">exitCode: int</span></tt> &lt;- the exit code as an integer</li>
 </ul>
+</p></blockquote>
+<ol class="simple" start="2"><li>allows to customize the error output behavior by handing the</li>
+</ol>
+<p>argument <tt class="docutils literal"><span class="pre">debugConfig</span></tt> (see below) as well as the process options with which <tt class="docutils literal"><span class="pre">startProcess</span></tt> is called by using the <tt class="docutils literal"><span class="pre">options</span></tt> argument.</p>
+<p>As you notice the macro signature is <tt class="docutils literal"><span class="pre">args: varargs[untyped]</span></tt>. This macro parses the given arguments manually (to allow multiple named arguments in an untyped macro). If the arguments are not named, they are expected in the order as shown below. <tt class="docutils literal"><span class="pre">combineOutAndErr</span></tt> has to be named!</p>
+<p>The following arguments are possible:</p>
+<ul class="simple"><li><tt class="docutils literal"><span class="pre">debug</span></tt>, <tt class="docutils literal"><span class="pre">debugConfig</span></tt>: a set of <tt class="docutils literal"><span class="pre">DebugOutputKind</span></tt></li>
+<li><tt class="docutils literal"><span class="pre">options</span></tt>, <tt class="docutils literal"><span class="pre">processOptions</span></tt>: a set of <tt class="docutils literal"><span class="pre">ProcessOption</span></tt> (see <tt class="docutils literal"><span class="pre">stdlib.osproc</span></tt>)</li>
+<li><tt class="docutils literal"><span class="pre">combineOutAndErr</span></tt>: a static bool to decide if the macro should return a 2 tuple of <tt class="docutils literal"><span class="pre">(output: string, errCode: int)</span></tt> (<tt class="docutils literal"><span class="pre">stderr</span></tt> is appended to <tt class="docutils literal"><span class="pre">stdout</span></tt>) or a 3 tuple of <tt class="docutils literal"><span class="pre">(output, outerr: string, errCode: int)</span></tt> (<tt class="docutils literal"><span class="pre">stderr</span></tt> separate) The latter can also be had by using the <tt class="docutils literal"><span class="pre">shellVerboseErr</span></tt> overload below.</li>
+</ul>
 
+<p><strong class="examples_text">Example:</strong></p>
+<pre class="listing"><span class="Keyword">let</span><span class="Whitespace"> </span><span class="Punctuation">(</span><span class="Identifier">res</span><span class="Punctuation">,</span><span class="Whitespace"> </span><span class="Identifier">code</span><span class="Punctuation">)</span><span class="Whitespace"> </span><span class="Operator">=</span><span class="Whitespace"> </span><span class="Identifier">shellVerbose</span><span class="Punctuation">(</span><span class="Identifier">debug</span><span class="Whitespace"> </span><span class="Operator">=</span><span class="Whitespace"> </span><span class="Punctuation">{</span><span class="Identifier">dokCommand</span><span class="Punctuation">}</span><span class="Punctuation">,</span><span class="Whitespace"> </span><span class="Identifier">options</span><span class="Whitespace"> </span><span class="Operator">=</span><span class="Whitespace"> </span><span class="Punctuation">{</span><span class="Identifier">poEvalCommand</span><span class="Punctuation">}</span><span class="Punctuation">,</span><span class="Whitespace">
+                               </span><span class="Identifier">combineOutAndErr</span><span class="Whitespace"> </span><span class="Operator">=</span><span class="Whitespace"> </span><span class="Identifier">true</span><span class="Punctuation">)</span><span class="Punctuation">:</span><span class="Whitespace">
+  </span><span class="Identifier">echo</span><span class="Whitespace"> </span><span class="StringLit">&quot;test&quot;</span><span class="Whitespace">
+
+</span><span class="Identifier">assert</span><span class="Whitespace"> </span><span class="Identifier">res</span><span class="Whitespace"> </span><span class="Operator">==</span><span class="Whitespace"> </span><span class="StringLit">&quot;test&quot;</span><span class="Whitespace">
+</span><span class="Identifier">assert</span><span class="Whitespace"> </span><span class="Identifier">code</span><span class="Whitespace"> </span><span class="Operator">==</span><span class="Whitespace"> </span><span class="DecNumber">0</span></pre>
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L406"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L536"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L406" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L536" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
-<a id="shellVerboseErr.m,untyped,untyped"></a>
-<dt><pre><span class="Keyword">macro</span> <a href="#shellVerboseErr.m%2Cuntyped%2Cuntyped"><span class="Identifier">shellVerboseErr</span></a><span class="Other">(</span><span class="Identifier">debugConfig</span><span class="Other">,</span> <span class="Identifier">cmds</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
+<a id="shellVerboseErr.m,varargs[untyped]"></a>
+<dt><pre><span class="Keyword">macro</span> <a href="#shellVerboseErr.m%2Cvarargs%5Buntyped%5D"><span class="Identifier">shellVerboseErr</span></a><span class="Other">(</span><span class="Identifier">args</span><span class="Other">:</span> <span class="Identifier">varargs</span><span class="Other">[</span><span class="Identifier">untyped</span><span class="Other">]</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
 <dd>
 
-Run shell command, return <tt class="docutils literal"><span class="pre">(stdout, stderr, code)</span></tt>. <tt class="docutils literal"><span class="pre">debugConfig</span></tt> is an configuration for shell execution
+Run shell command, return <tt class="docutils literal"><span class="pre">(stdout, stderr, code)</span></tt>. This is an overload of <tt class="docutils literal"><span class="pre">shellVerbose</span></tt> with <tt class="docutils literal"><span class="pre">combineOutAndErr = false</span></tt> by default.
 <p><strong class="examples_text">Example:</strong></p>
 <pre class="listing"><span class="Keyword">let</span><span class="Whitespace"> </span><span class="Punctuation">(</span><span class="Identifier">res</span><span class="Punctuation">,</span><span class="Whitespace"> </span><span class="Identifier">err</span><span class="Punctuation">,</span><span class="Whitespace"> </span><span class="Identifier">code</span><span class="Punctuation">)</span><span class="Whitespace"> </span><span class="Operator">=</span><span class="Whitespace"> </span><span class="Identifier">shellVerboseErr</span><span class="Whitespace"> </span><span class="Punctuation">{</span><span class="Identifier">dokCommand</span><span class="Punctuation">}</span><span class="Punctuation">:</span><span class="Whitespace">
   </span><span class="Identifier">echo</span><span class="Whitespace"> </span><span class="StringLit">&quot;test&quot;</span><span class="Whitespace">
@@ -271,42 +281,9 @@ Run shell command, return <tt class="docutils literal"><span class="pre">(stdout
 </span><span class="Identifier">assert</span><span class="Whitespace"> </span><span class="Identifier">res</span><span class="Whitespace"> </span><span class="Operator">==</span><span class="Whitespace"> </span><span class="StringLit">&quot;test&quot;</span><span class="Whitespace">
 </span><span class="Identifier">assert</span><span class="Whitespace"> </span><span class="Identifier">code</span><span class="Whitespace"> </span><span class="Operator">==</span><span class="Whitespace"> </span><span class="DecNumber">0</span></pre>
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L467"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L573"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L467" class="link-seesrc" target="_blank" >Edit</a>
-
-</dd>
-<a id="shellVerboseErr.m,untyped"></a>
-<dt><pre><span class="Keyword">macro</span> <a href="#shellVerboseErr.m%2Cuntyped"><span class="Identifier">shellVerboseErr</span></a><span class="Other">(</span><span class="Identifier">cmds</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
-<dd>
-
-
-&nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L481"
-class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L481" class="link-seesrc" target="_blank" >Edit</a>
-
-</dd>
-<a id="shellVerbose.m,untyped,untyped"></a>
-<dt><pre><span class="Keyword">macro</span> <a href="#shellVerbose.m%2Cuntyped%2Cuntyped"><span class="Identifier">shellVerbose</span></a><span class="Other">(</span><span class="Identifier">debugConfig</span><span class="Other">,</span> <span class="Identifier">cmds</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
-<dd>
-
-
-&nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L486"
-class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L486" class="link-seesrc" target="_blank" >Edit</a>
-
-</dd>
-<a id="shellVerbose.m,untyped"></a>
-<dt><pre><span class="Keyword">macro</span> <a href="#shellVerbose.m%2Cuntyped"><span class="Identifier">shellVerbose</span></a><span class="Other">(</span><span class="Identifier">cmds</span><span class="Other">:</span> <span class="Identifier">untyped</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
-<dd>
-
-
-&nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L497"
-class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L497" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L573" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
 <a id="shell.m,untyped"></a>
@@ -321,13 +298,14 @@ shellCmd:
 <p><pre class="listing">
 shell&gt;
 </pre></p>
+<p>If multiple commands are run in succession (i.e. multiple statements in the macro body) and one command returns a non-zero exit code, the following commands will not be run. Instead a warning message will be shown.</p>
 <p>For usage with NimScript the output can only be echoed after the call has finished.</p>
 <p>The exit code of the command is dropped. If you wish to inspect the exit code, use <tt class="docutils literal"><span class="pre">shellVerbose</span></tt> above.</p>
 
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L502"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L589"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L502" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L589" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
 <a id="shellEcho.m,untyped"></a>
@@ -336,9 +314,9 @@ class="link-seesrc" target="_blank">Source</a>
 
 a helper macro around the proc that generates the shell commands to check whether the commands are as expected It echoes the commands at compile time (the representation of the command) and also the resulting string (taking into account potential) Nim symbol quoting at run time
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L524"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L616"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L524" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L616" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
 <a id="checkShell.m,untyped,untyped"></a>
@@ -347,9 +325,9 @@ class="link-seesrc" target="_blank">Source</a>
 
 a wrapper around the shell macro, which can calls <tt class="docutils literal"><span class="pre">unittest.check</span></tt> to check whether construction of the commands works as expected
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L541"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L633"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L541" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L633" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
 <a id="shellAssign.m,untyped"></a>
@@ -358,9 +336,9 @@ class="link-seesrc" target="_blank">Source</a>
 
 
 &nbsp;&nbsp;<a
-href="https://github.com/Vindaar/shell/tree/master/shell.nim#L559"
+href="https://github.com/Vindaar/shell/tree/master/shell.nim#L651"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L559" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="https://github.com/Vindaar/shell/edit/master/shell.nim#L651" class="link-seesrc" target="_blank" >Edit</a>
 
 </dd>
 
@@ -373,7 +351,7 @@ class="link-seesrc" target="_blank">Source</a>
       <div class="twelve-columns footer">
         <span class="nim-sprite"></span>
         <br/>
-        <small style="color: var(--hint);">Made with Nim. Generated: 2020-12-27 08:19:30 UTC</small>
+        <small style="color: var(--hint);">Made with Nim. Generated: 2020-12-30 10:41:06 UTC</small>
       </div>
     </div>
   </div>

--- a/docs/shell.idx
+++ b/docs/shell.idx
@@ -4,13 +4,10 @@ dokOutput	shell.html#dokOutput	DebugOutputKind.dokOutput
 dokRuntime	shell.html#dokRuntime	DebugOutputKind.dokRuntime	
 DebugOutputKind	shell.html#DebugOutputKind	shell: DebugOutputKind	
 ShellExecError	shell.html#ShellExecError	shell: ShellExecError	
-asgnShell	shell.html#asgnShell,string,set[DebugOutputKind]	shell: asgnShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig): tuple[\n    output, error: string, exitCode: int]	
-execShell	shell.html#execShell,string,set[DebugOutputKind]	shell: execShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig): tuple[\n    output, error: string, exitCode: int]	
-shellVerboseImpl	shell.html#shellVerboseImpl.m,untyped,untyped	shell: shellVerboseImpl(debugConfig, cmds: untyped): untyped	
-shellVerboseErr	shell.html#shellVerboseErr.m,untyped,untyped	shell: shellVerboseErr(debugConfig, cmds: untyped): untyped	
-shellVerboseErr	shell.html#shellVerboseErr.m,untyped	shell: shellVerboseErr(cmds: untyped): untyped	
-shellVerbose	shell.html#shellVerbose.m,untyped,untyped	shell: shellVerbose(debugConfig, cmds: untyped): untyped	
-shellVerbose	shell.html#shellVerbose.m,untyped	shell: shellVerbose(cmds: untyped): untyped	
+asgnShell	shell.html#asgnShell,string,set[DebugOutputKind],set[ProcessOption]	shell: asgnShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig;\n          options: set[ProcessOption] = defaultProcessOptions): tuple[\n    output, error: string, exitCode: int]	
+execShell	shell.html#execShell,string,set[DebugOutputKind],set[ProcessOption]	shell: execShell(cmd: string; debugConfig: set[DebugOutputKind] = defaultDebugConfig;\n          options: set[ProcessOption] = defaultProcessOptions): tuple[\n    output, error: string, exitCode: int]	
+shellVerbose	shell.html#shellVerbose.m,varargs[untyped]	shell: shellVerbose(args: varargs[untyped]): untyped	
+shellVerboseErr	shell.html#shellVerboseErr.m,varargs[untyped]	shell: shellVerboseErr(args: varargs[untyped]): untyped	
 shell	shell.html#shell.m,untyped	shell: shell(cmds: untyped): untyped	
 shellEcho	shell.html#shellEcho.m,untyped	shell: shellEcho(cmds: untyped): untyped	
 checkShell	shell.html#checkShell.m,untyped,untyped	shell: checkShell(cmds: untyped; exp: untyped): untyped	

--- a/shell.nim
+++ b/shell.nim
@@ -276,7 +276,17 @@ proc asgnShell*(
   ## wrapper around `execCmdEx`, which returns the output of the shell call
   ## as a string (stripped of `\n`)
   when not defined(NimScript):
-    let pid = startProcess(cmd, options = options)
+    when defined(windows):
+      var pid: Process
+      try:
+        pid = startProcess(cmd, options = options)
+      except OSError as e:
+        let exitCode = 1
+        let err = e.msg
+        return (output: "", error: err, exitCode: exitCode)
+    else:
+      let pid = startProcess(cmd, options = options)
+
     let outStream = pid.outputStream
     var line = ""
     var res = ""

--- a/shell.nim
+++ b/shell.nim
@@ -58,7 +58,10 @@ const defaultDebugConfig: set[DebugOutputKind] =
 
     config
 
-const defaultProcessOptions: set[ProcessOption] = {poStdErrToStdOut, poEvalCommand}
+when defined(windows):
+  const defaultProcessOptions: set[ProcessOption] = {poStdErrToStdOut, poEvalCommand, poDaemon, poUsePath}
+else:
+  const defaultProcessOptions: set[ProcessOption] = {poStdErrToStdOut, poEvalCommand}
 # this default is used for `shellVerboseErr` where we do ``not`` want to combine stdout
 # and stderr.
 const defaultProcessOptionsErr: set[ProcessOption] = {poEvalCommand}

--- a/shell.nim
+++ b/shell.nim
@@ -307,10 +307,8 @@ proc asgnShell*(
 
     # Zero exit code does not guarantee that there will be nothing in
     # stderr.
-
     let err = pid.errorStream
     let errorText = err.readAll()
-    err.close()
 
     if exitCode != 0:
       if dokRuntime in debugConfig:

--- a/shell.nim
+++ b/shell.nim
@@ -2,6 +2,12 @@ import macros
 when not defined(NimScript):
   import osproc, streams, os
   export osproc
+else:
+  type
+    # dummy enum, which has no effect on NimScript
+    ProcessOption* = enum
+      poEchoCmd, poUsePath, poEvalCommand, poStdErrToStdOut, poParentStreams,
+      poInteractive, poDaemon
 import strutils, strformat
 export strformat
 

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -270,90 +270,89 @@ suite "[shell]":
     do:
       $myCmd
 
-  when not defined(windows):
-    ## these tests don't work on windows, since the commands don't exist
-    test "[shellAssign] assigning output of a shell call to a Nim var":
-      var res = ""
-      shellAssign:
-        res = echo `hello`
-      check res == "hello"
+  ## these tests don't work on windows, since the commands don't exist
+  test "[shellAssign] assigning output of a shell call to a Nim var":
+    var res = ""
+    shellAssign:
+      res = echo `hello`
+    check res == "hello"
 
-    test "[shellAssign] assigning output of a shell pipe to a Nim var":
-      var res = ""
-      shellAssign:
-        res = pipe:
-          seq 0 1 10
-          tail -3
-      when not defined(travisCI):
-        # test is super flaky on travis. Often thee 10 is missing?!
-        check res.multiReplace([("\n", "")]) == "8910"
+  test "[shellAssign] assigning output of a shell pipe to a Nim var":
+    var res = ""
+    shellAssign:
+      res = pipe:
+        seq 0 1 10
+        tail -3
+    when not defined(travisCI):
+      # test is super flaky on travis. Often thee 10 is missing?!
+      check res.multiReplace([("\n", "")]) == "8910"
 
-    test "[shellAssign] assigning output from shell to a variable while quoting a Nim var":
-      var res = ""
-      let name1 = "Lucian"
-      let name2 = "Markus"
-      shellAssign:
-        res = echo "Hello " ($name1) "and" ($name2)
-      check res == "Hello Lucian and Markus"
+  test "[shellAssign] assigning output from shell to a variable while quoting a Nim var":
+    var res = ""
+    let name1 = "Lucian"
+    let name2 = "Markus"
+    shellAssign:
+      res = echo "Hello " ($name1) "and" ($name2)
+    check res == "Hello Lucian and Markus"
 
-    test "[shell] real time output":
-      shell:
-        "for f in 1 2 3; do echo $f; sleep 1; done"
+  test "[shell] real time output":
+    shell:
+      "for f in 1 2 3; do echo $f; sleep 1; done"
 
-    test "[shellVerbose] check for exit code of wrong command":
-      let res = shellVerbose:
-        thisCommandDoesNotExistOnYourSystemOrThisTestWillFail
-      check res[1] != 0
+  test "[shellVerbose] check for exit code of wrong command":
+    let res = shellVerbose:
+      thisCommandDoesNotExistOnYourSystemOrThisTestWillFail
+    check res[1] != 0
 
-    test "[shellVerbose] compare output of command using shellVerbose":
-      let res = shellVerbose:
-        echo "Hello world!"
-      check res[0] == "Hello world!"
-      check res[1] == 0
+  test "[shellVerbose] compare output of command using shellVerbose":
+    let res = shellVerbose:
+      echo "Hello world!"
+    check res[0] == "Hello world!"
+    check res[1] == 0
 
-    test "[shellVerbose] remove nested StmtLists":
-      var toContinue = true
-      template tc(cmd: untyped): untyped {.dirty.} =
-        if toContinue:
-          toContinue = cmd
+  test "[shellVerbose] remove nested StmtLists":
+    var toContinue = true
+    template tc(cmd: untyped): untyped {.dirty.} =
+      if toContinue:
+        toContinue = cmd
 
-      template shellCheck(actions: untyped): untyped =
-        tc:
-          let res = shellVerbose:
-            actions
-          res[1] == 0
+    template shellCheck(actions: untyped): untyped =
+      tc:
+        let res = shellVerbose:
+          actions
+        res[1] == 0
 
-      shellCheck:
-        one:
-          "f=hallo"
-          echo $f
-      check toContinue
+    shellCheck:
+      one:
+        "f=hallo"
+        echo $f
+    check toContinue
 
-    test "[shellVerbose] check commands are not run after failure":
-      let res = shellVerbose:
-        echo runBrokenCommand
-        thisCommandDoesNotExistOnYourSystemOrThisTestWillFail
-        echo Hello
-      check res[1] != 0
-      check res[0].startsWith("runBrokenCommand")
+  test "[shellVerbose] check commands are not run after failure":
+    let res = shellVerbose:
+      echo runBrokenCommand
+      thisCommandDoesNotExistOnYourSystemOrThisTestWillFail
+      echo Hello
+    check res[1] != 0
+    check res[0].startsWith("runBrokenCommand")
 
-    test "[shellVerboseErr] check stderr output":
-      let test = "test"
-      let (res, err, _) = shellVerboseErr:
-        echo ($test)
-        echo ($test) >&2
+  test "[shellVerboseErr] check stderr output":
+    let test = "test"
+    let (res, err, _) = shellVerboseErr:
+      echo ($test)
+      echo ($test) >&2
 
-      doAssert test == res
-      doAssert test == err
+    doAssert test == res
+    doAssert test == err
 
-    test "[shellVerboseErr] setting debug config works":
-      let test = "test"
-      let (res, err, _) = shellVerboseErr {dokOutput}:
-        echo ($test)
+  test "[shellVerboseErr] setting debug config works":
+    let test = "test"
+    let (res, err, _) = shellVerboseErr {dokOutput}:
+      echo ($test)
 
-      doAssert test == res
+    doAssert test == res
 
-    test "[shellVerbose] change process options":
-      let (res, err) = shellVerbose(options = {poEvalCommand}):
-        echo "Hello World"
-      check res == "Hello World"
+  test "[shellVerbose] change process options":
+    let (res, err) = shellVerbose(options = {poEvalCommand}):
+      echo "Hello World"
+    check res == "Hello World"

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -345,3 +345,15 @@ suite "[shell]":
 
       doAssert test == res
       doAssert test == err
+
+    test "[shellVerboseErr] setting debug config works":
+      let test = "test"
+      let (res, err, _) = shellVerboseErr {dokOutput}:
+        echo ($test)
+
+      doAssert test == res
+
+    test "[shellVerbose] change process options":
+      let (res, err) = shellVerbose(options = {poEvalCommand}):
+        echo "Hello World"
+      check res == "Hello World"


### PR DESCRIPTION
This PR was supposed to only allow the user to customize the process options, which are passed to `startProcess`, but I ended up having to change some of the internals to allow multiple arguments to the macros without getting into problems with untyped identifiers in the macro body.

It seems that on Windows (and now on linux as well?) not using `poEvalCommand` (which we did not use by default) does not properly work, because the `cmd` argument is really interpreted as a single system command. I'm really confused why this worked before, because now it doesn't work without it anymore.
We depend on handing a single string instead of running a command, because obviously we *want* to use the system shell and might run multiple commands in one shell. So `poEvalCommand` seems a common sense default.

The internals were changed a bit in the sense that `shellVerboseImpl` now handles everything, but receives typed input instead of being a macro. `shellVerbose` performs parsing of all possible macro arguments from an `args: varargs[untyped]`. Named and unnamed arguments are possible. The arguments are as follows, from the docstring:
```
  ## - `debug`, `debugConfig`: a set of `DebugOutputKind`
  ## - `options`, `processOptions`: a set of `ProcessOption` (see `stdlib.osproc`)
  ## - `combineOutAndErr`: a static bool to decide if the macro should return a
  ##   2 tuple of `(output: string, errCode: int)` (`stderr` is appended to `stdout`)
  ##   or a 3 tuple of `(output, outerr: string, errCode: int)` (`stderr` separate)
  ##   The latter can also be had by using the `shellVerboseErr` overload below.
```
If arguments are given as unnamed the order is expected as stated here.

@haxscramper It'd be great if you could check if I didn't break anything on your end (if you use the debug config options somewhere).
Otherwise I'm all ears on the naming of the arguments (`combineOutAndErr` in particular) and general feedback of course!