### PR TITLE
Allow `nnkAsgn` nodes

### DIFF
--- a/README.org
+++ b/README.org
@@ -320,12 +320,35 @@ shell:
     echo $a
 #+END_SRC
 
-Also if you need assignment via ':' or '=', put it also in quotation
-marks. Say you wish to compile a Nim program, you might want to do:
+Also if you need assignment via `:`, you need to also put it into quotation
+marks, as the Nim tree is not unambiguous enough to properly parse the
+resulting command. Say you wish to compile a Nim program, you might want to do:
 #+BEGIN_SRC nim
 shell:
   nim c "--out:noTest" test.nim
 #+END_SRC
+
+A slightly different case is assignment via `=`. A single `=`
+assignment in a command is possible, but not more. That is due to a
+Nim parser limitation (as you cannot have "nested" `nnkAsgn` nodes).
+
+So this:
+#+begin_src sh
+shel:
+  foo --bar --option=value --more
+#+end_src
+is fine, but this:
+#+begin_src sh
+shell:
+  foo --bar --option=value --secondOption=value2
+#+end_src
+is *not* valid Nim syntax. Fortunately, in most cases the `=` sign is
+optional anyway and you may just drop (one or both):
+#+begin_src sh
+shel:
+  foo --bar --option value --secondOption value2
+#+end_src
+is valid and means the same for most programs.
 
 In general, if in doubt you can just write strings or triple string
 (to pass a ="= to the shell).

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.4.4
+- allow (single) `nnkAsgn` in macro, e.g. to write
+  =foo --option=value --more=. Note that only a single assignment is valid.
 * v0.4.3
 - replace travis CI by Github Actions (now includes Windows and OSX
   testing)

--- a/shell.nim
+++ b/shell.nim
@@ -414,6 +414,11 @@ proc genShellCmds(cmds: NimNode): seq[string] =
       result.add iterateTree(nnkIdentDefs.newTree(cmd))
     of nnkPar:
       result.add cmd.stringify
+    of nnkAsgn:
+      # handle first child, then second
+      let lhs = iterateTree(cmd[0])
+      let rhs = iterateTree(cmd[1])
+      result.add concatCmds(@[lhs, rhs], sep = "=")
     else:
       error("Unsupported node kind: " & $cmd.kind & " for command " & cmd.repr &
         ". Consider putting offending part into \" \".")

--- a/shell.nim
+++ b/shell.nim
@@ -416,8 +416,8 @@ proc genShellCmds(cmds: NimNode): seq[string] =
       result.add cmd.stringify
     of nnkAsgn:
       # handle first child, then second
-      let lhs = iterateTree(cmd[0])
-      let rhs = iterateTree(cmd[1])
+      let lhs = stringify(cmd[0])
+      let rhs = stringify(cmd[1])
       result.add concatCmds(@[lhs, rhs], sep = "=")
     else:
       error("Unsupported node kind: " & $cmd.kind & " for command " & cmd.repr &

--- a/tests/tShell.nim
+++ b/tests/tShell.nim
@@ -69,6 +69,12 @@ suite "[shell]":
     do:
       "./reconstruction Run123 --out=\"test.h5\""
 
+  test "[shell] single cmd with `nnkAsgn`":
+    checkShell:
+      ./reconstruction Run123 --out=test.h5 --foo
+    do:
+      "./reconstruction Run123 --out=test.h5 --foo"
+
   test "[shell] command with a redirect":
     checkShell:
       echo """"test file"""" > test.txt


### PR DESCRIPTION
This allows `nnkAsgn` nodes in an expression.

Note that these are limited to a single `=`, as any more is a parser error.