### PR TITLE
Add `expect` / `send` construct

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,6 +80,65 @@ shell:
 #+END_SRC
 will work just as expected, echoing =Hallo= in the shell.
 
+** Handling programs that require user input
+
+Some terminal commands will require user input. Starting from version
+=v0.5.0=, basic support for a =expect= / =send= feature is
+available. It allows for functionality similar to the
+[[https://linux.die.net/man/1/expect][=expect(1)= program]].
+
+Let's consider two simple examples. Assuming we have a script that
+reads from =stdin= such as:
+
+=tExpect.sh=:
+#+begin_src sh
+#!/bin/sh
+
+echo "Hello world. Your name?"
+read foo
+echo "Your name is" $foo
+#+end_src
+
+calling this script using the =shell= macro would normally
+#+begin_src nim
+import shell
+shell:
+  ./tExpect.sh
+#+end_src
+cause the nim program to simply stop upon encountering the =read=
+line. Using =expect= / =send= we can handle this:
+
+#+begin_src nim
+import shell
+shell:
+  ./tExpect.sh
+  expect: "Your name?"
+  send: "BaFu"
+#+end_src
+As you notice the =expect= line only contains the second part of the
+last printed line of the shell script. That is because the =expect=
+functionality tries to match the shell output line by line using one
+of the following:
+- the =expect= line matches exactly
+- the line starts with the =expect= line
+- the line ends with the =expect= line (useful for long outputs that
+  end with ="y/N"= like constructs)
+(this may become configurable in the future)
+
+Another example would be installing a nimble package and dealing with
+the possibility of having to upgrade / overwrite package:
+#+begin_src nim
+import shell
+shell:
+  nimble install foo
+  expect: "Overwrite? [y/N]"
+  send: "y"
+#+end_src
+which handles such situations programatically.
+
+*Note*: You may have multiple =expect= / =send= constructs in a single
+=shell= call. But keep in mind that every =expect= must have a =send=.
+
 ** Nim symbol quoting
 
 *NOTE:* In a previous version this was done via accented quotes

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.5.0
+- add =expect= / =send= construct to DSL
 * v0.4.4
 - allow (single) `nnkAsgn` in macro, e.g. to write
   =foo --option=value --more=. Note that only a single assignment is valid.

--- a/shell.nim
+++ b/shell.nim
@@ -695,6 +695,46 @@ macro shell*(cmds: untyped): untyped =
   ##
   ## The exit code of the command is dropped. If you wish to inspect
   ## the exit code, use `shellVerbose` above.
+  ##
+  ## Within the DSL a few extra commands exist.
+  ##
+  ## ```nim
+  ## shell:
+  ##   one:
+  ##     cmd 1
+  ##     cmd 2 ...
+  ## ```
+  ##
+  ## `one` can be used to run multiple commands in the same invocation. Each command
+  ## combined via `&&` in the shell.
+  ##
+  ## ```nim
+  ## shell:
+  ##   pipe:
+  ##     cmd 1
+  ##     cmd 2 ...
+  ## ```
+  ##
+  ## `pipe` can be used to pipe together multiple commands. Each command is combined
+  ## `|` in the shell.
+  ##
+  ## Finally, there is an `expect` / `send` feature, somewhat similar to the `expect(1)`
+  ## program.
+  ##
+  ## ```nim
+  ## shell:
+  ##   commandThatNeedsInput
+  ##   expect: "Some text to match"
+  ##   send: "Some text to answer"
+  ## ```
+  ##
+  ## The code tries to match output line after `commandThatNeedsInput` is run by the
+  ## argument to `expect`. Currently it simply tries to match
+  ## - the whole line
+  ## - only the beginning
+  ## - only the end
+  ## (this will probably become configurable in the future)
+  ## Upon a match, the `send` argument will be sent to the process.
   result = quote do:
     discard shellVerbose(debug = defaultDebugConfig, options = defaultProcessOptions):
       `cmds`

--- a/shell.nimble
+++ b/shell.nimble
@@ -19,6 +19,7 @@ task test, "executes the tests":
   # which itself calls the test
   when not defined(windows):
     exec "cd tests/anotherDir && nim e -r runAnotherTest.nims"
+    exec "nim c -r tests/tExpect.nim"
 
 task travis, "executes the tests on travis":
   exec "nim c -d:debugShell -d:travisCI -r tests/tShell.nim"

--- a/tests/tExpect.nim
+++ b/tests/tExpect.nim
@@ -1,0 +1,13 @@
+import ../shell
+import std / unittest
+
+# only run on linux due to the tExpect shell script (and not any platform bindings
+# of the `expect` support)
+when defined(linux):
+  var res = ""
+  shellAssign:
+    res = "./tests/tExpect.sh"
+    expect: "Your name?"
+    send: "Vindaar"
+  check res == """Hello world. Your name?
+Your name is Vindaar"""

--- a/tests/tExpect.sh
+++ b/tests/tExpect.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Hello world. Your name?"
+read foo
+echo "Your name is" $foo


### PR DESCRIPTION
This adds support to deal with processes that require user input via a `expect` / `send` construct somewhat similar to expect(1).

See the README and added test for an example.

Closes #20.