### PR TITLE
Allow `send` without `expect`, fixes #22

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.5.1
+- ~send~ can now be used without an explicit ~expect~
 * v0.5.0
 - add =expect= / =send= construct to DSL
 * v0.4.4

--- a/tests/tExpect.nim
+++ b/tests/tExpect.nim
@@ -4,10 +4,20 @@ import std / unittest
 # only run on linux due to the tExpect shell script (and not any platform bindings
 # of the `expect` support)
 when defined(linux):
-  var res = ""
-  shellAssign:
-    res = "./tests/tExpect.sh"
-    expect: "Your name?"
-    send: "Vindaar"
-  check res == """Hello world. Your name?
+  block:
+    var res = ""
+    shellAssign:
+      res = "./tests/tExpect.sh"
+      expect: "Your name?"
+      send: "Vindaar"
+    check res == """Hello world. Your name?
+Your name is Vindaar"""
+
+  block:
+    # now try without the `expect`
+    var res = ""
+    shellAssign:
+      res = "./tests/tExpect.sh"
+      send: "Vindaar"
+    check res == """Hello world. Your name?
 Your name is Vindaar"""


### PR DESCRIPTION
Here's a (hopefully not broken) :christmas_tree: :gift: :partying_face:.