### PR TITLE
Print PID of spawned process

### DIFF
--- a/shell.nim
+++ b/shell.nim
@@ -607,6 +607,7 @@ proc parseShellVerboseArgs(combineOutAndErrDefault: bool,
     case arg.kind
     of nnkExprEqExpr:
       let argStr = arg[0].strVal
+      const allowedArgs = ["debug", "debugConfig", "options", "processOptions", "combineOutAndErr"]
       case argStr
       of "debug", "debugConfig":
         cfgArg = parseDebugConfig(arg[1])
@@ -614,6 +615,8 @@ proc parseShellVerboseArgs(combineOutAndErrDefault: bool,
         optArg = parseProcessOptions(arg[1])
       of "combineOutAndErr":
         combineOutAndErr = parseCombineAndErr(arg[1])
+      else:
+        error("Invalid named argument to `shellVerbose`: " & $argStr & ". Allowed arguments: " & $allowedArgs)
     of nnkCurly:
       if idx == 0:
         cfgArg = parseDebugConfig(arg)

--- a/shell.nim
+++ b/shell.nim
@@ -784,6 +784,21 @@ macro shellEcho*(cmds: untyped): untyped =
     result.add quote do:
       echo `qCmd`
 
+macro shellCmd*(cmds: untyped): untyped =
+  ## a helper macro around the proc that generates the shell commands
+  ## to get the generated command as a runtime string.
+  expectKind cmds, nnkStmtList
+  let shCmds = genShellCmds(cmds)
+  doAssert shCmds.len == 1, "Can only handle a single command at this time"
+  var res = ""
+  #for cmd in shCmds:
+  #  let qCmd = nilOrQuote(cmd)
+  #  # echo representation at compile time
+  #  echo qCmd.repr
+  #  # and echo
+  #  res.add qCmd.str
+  result = nilOrQuote(shCmds[0])
+
 macro checkShell*(cmds: untyped, exp: untyped): untyped =
   ## a wrapper around the shell macro, which can calls `unittest.check` to
   ## check whether construction of the commands works as expected


### PR DESCRIPTION
By default `shell` will now print the process ID of the process it spawned. This is convenient to identify output of different processes spawned from a single program.

It can be disabled by setting `-d:PrintPid=false`.